### PR TITLE
fix maker address issue

### DIFF
--- a/src/order-builder/helpers.ts
+++ b/src/order-builder/helpers.ts
@@ -173,10 +173,8 @@ const buildOrder = async (signer: Wallet | JsonRpcSigner, args: OrderCreationArg
 
     // And sign it with the maker address
     const limitOrderTypedData = limitOrderBuilder.buildLimitOrderTypedData(limitOrder);
-    const limitOrderSignature = await limitOrderBuilder.buildOrderSignature(
-        jsonRpcSigner._address,
-        limitOrderTypedData,
-    );
+    const address = await jsonRpcSigner.getAddress();
+    const limitOrderSignature = await limitOrderBuilder.buildOrderSignature(address, limitOrderTypedData);
 
     const orderAndSignature: LimitOrderAndSignature = {
         order: limitOrder,
@@ -220,7 +218,8 @@ const buildMarketOrder = async (signer: Wallet | JsonRpcSigner, args: MarketOrde
 
     // And sign it with the maker address
     const typedData = marketOrderBuilder.buildOrderTypedData(marketOrder);
-    const sig = await marketOrderBuilder.buildOrderSignature(jsonRpcSigner._address, typedData);
+    const address = await jsonRpcSigner.getAddress();
+    const sig = await marketOrderBuilder.buildOrderSignature(address, typedData);
 
     const orderAndSignature: MarketOrderAndSignature = {
         order: marketOrder,


### PR DESCRIPTION
Fix this issue when signing an order w/Metamask.
<img width="1303" alt="Screen Shot 2022-03-01 at 19 58 12" src="https://user-images.githubusercontent.com/7882933/156263243-e7f9504a-431a-4fb4-9a7d-9ff632d8c8c0.png">

Looks like `_address`  field is not available when using metamask.