### PR TITLE
large-orders endpoint

### DIFF
--- a/examples/getLargeOrders.ts
+++ b/examples/getLargeOrders.ts
@@ -1,0 +1,31 @@
+import { ethers } from "ethers";
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+import { ApiKeyCreds, ClobClient } from "../src";
+
+dotenvConfig({ path: resolve(__dirname, "../.env") });
+
+async function main() {
+    const provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL);
+    const pk = new ethers.Wallet(`${process.env.PK}`);
+    const wallet = pk.connect(provider);
+    console.log(`Address: ${await wallet.getAddress()}`);
+
+    const host = process.env.CLOB_API_URL || "http://localhost:8080";
+    const creds: ApiKeyCreds = {
+        key: `${process.env.CLOB_API_KEY}`,
+        secret: `${process.env.CLOB_SECRET}`,
+        passphrase: `${process.env.CLOB_PASS_PHRASE}`,
+    };
+    const clobClient = new ClobClient(host, wallet, creds);
+
+    const resp = await clobClient.getLargeOrders();
+    console.log(resp);
+
+    // Filtered
+    const filtered = await clobClient.getLargeOrders("1000");
+    console.log(filtered);
+    console.log(`Done!`);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.0.32",
+    "version": "1.0.33",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,6 +37,7 @@ import {
     ORDER_HISTORY,
     DERIVE_API_KEY,
     GET_LAST_TRADE_PRICE,
+    GET_LARGE_ORDERS,
 } from "./endpoints";
 import { OrderBuilder } from "./order-builder/builder";
 
@@ -94,6 +95,11 @@ export class ClobClient {
 
     public async getLastTradePrice(tokenID: string): Promise<any> {
         return get(`${this.host}${GET_LAST_TRADE_PRICE}?market=${tokenID}`);
+    }
+
+
+    public async getLargeOrders(minValue: string = ""): Promise<any> {
+        return get(`${this.host}${GET_LARGE_ORDERS}?min_value=${minValue}`);
     }
 
     // L1 Authed

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -29,3 +29,5 @@ export const CANCEL = "/order";
 export const CANCEL_ALL = "/cancel-all";
 
 export const GET_LAST_TRADE_PRICE = "/last-trade-price";
+
+export const GET_LARGE_ORDERS = "/large-orders";


### PR DESCRIPTION
## Overview

Adding a new endpoint to tracker: `GET {endpoint}/large-orders`.

This new endpoint allows a query param to filter the min value of the orders: `?min_value=xxxxx`. If this param is not included the default value is `1000`.

The `value` of an order is calculated by multiplying its `price` and `size`.