### PR TITLE
bug fix for UnhandledPromiseRejectionWarning: TypeError: url.at is no…

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -44,7 +44,7 @@ export const marketOrderToJson = (mktOrder: MarketOrderAndSignature): any => {
 
 const buildQueryParams = (url: string, param: string, value: string): string => {
     let urlWithParams = url;
-    const last = url.at(url.length - 1);
+    const last = url.charAt(url.length - 1);
     // Check the last char in the url string
     // if ?, append the param directly: api.com?param=value
     if (last === "?") {


### PR DESCRIPTION
When I run getMarketOrderHistory.ts example I'm getting
(node:4712) UnhandledPromiseRejectionWarning: TypeError: url.at is not a function
    at buildQueryParams (E:\clob-client\src\utilities.ts:47:22)
    at Object.exports.addQueryParamsToUrl (E:\clob-client\src\utilities.ts:64:19)
    at ClobClient.<anonymous> (E:\clob-client\src\client.ts:245:21)
    at step (E:\clob-client\src\client.ts:33:23)
    at Object.next (E:\clob-client\src\client.ts:14:53)
    at fulfilled (E:\clob-client\src\client.ts:5:58)
   
   This small change should fix that