### PR TITLE
Add support for orders enpoint

### DIFF
--- a/examples/getOpenOrders.ts
+++ b/examples/getOpenOrders.ts
@@ -18,14 +18,11 @@ async function main() {
     };
     const clobClient = new ClobClient(host, chainId, wallet, creds);
 
-    const resp = await clobClient.getOpenOrders();
-    console.log(resp);
-
-    // Filtered
-    const filteredByMarket = await clobClient.getOpenOrders({
+    const resp = await clobClient.getOpenOrders({
         market: "16678291189211314787145083999015737376658799626183230671758641503291735614088",
+        owner: creds.key,
     });
-    console.log(filteredByMarket);
+    console.log(resp);
     console.log(`Done!`);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "contributors": [
         {
             "name": "Jonathan Amenechi",
@@ -10,6 +10,10 @@
         {
             "name": "Rodrigo Calvo",
             "url": "https://github.com/poly-rodr"
+        },
+        {
+            "name": "Matt Walker",
+            "url": "https://github.com/mttwlkr"
         }
     ],
     "main": "dist/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,21 +3,23 @@ import { JsonRpcSigner } from "@ethersproject/providers";
 import { SignatureType, SignedOrder } from "@polymarket/order-utils";
 import {
     ApiKeyCreds,
-    OrderPayload,
-    UserOrder,
-    OpenOrdersResponse,
-    Order,
     ApiKeysResponse,
-    FilterParams,
-    OrderHistory,
-    OptionalParams,
     Chain,
-    TradeParams,
+    FilterParams,
+    OpenOrdersParams,
+    OpenOrdersResponse,
+    OptionalParams,
+    Order,
+    OrderHistory,
+    OrderPayload,
     Trade,
+    TradeParams,
+    UserOrder,
 } from "./types";
 import { createL1Headers, createL2Headers } from "./headers";
 import {
     addFilterParamsToUrl,
+    addOpenOrderParamsToUrl,
     addTradeParamsToUrl,
     del,
     DELETE,
@@ -42,10 +44,10 @@ import {
     MIDPOINT,
     PRICE,
     OPEN_ORDERS,
-    ORDER_HISTORY,
     DERIVE_API_KEY,
     GET_LAST_TRADE_PRICE,
     GET_LARGE_ORDERS,
+    ORDER_HISTORY,
 } from "./endpoints";
 import { OrderBuilder } from "./order-builder/builder";
 
@@ -261,7 +263,7 @@ export class ClobClient {
         return this.orderBuilder.buildOrder(userOrder);
     }
 
-    public async getOpenOrders(params?: FilterParams): Promise<OpenOrdersResponse> {
+    public async getOpenOrders(params?: OpenOrdersParams): Promise<OpenOrdersResponse> {
         this.canL2Auth();
         const endpoint = OPEN_ORDERS;
         const l2HeaderArgs = {
@@ -275,7 +277,7 @@ export class ClobClient {
             l2HeaderArgs,
         );
 
-        const url = addFilterParamsToUrl(`${this.host}${endpoint}`, params);
+        const url = addOpenOrderParamsToUrl(`${this.host}${endpoint}`, params);
         return get(url, headers);
     }
 

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -20,7 +20,7 @@ export const ORDER_HISTORY = "/order-history";
 
 export const GET_ORDER = "/order/";
 
-export const OPEN_ORDERS = "/open-orders";
+export const OPEN_ORDERS = "/orders";
 
 export const POST_ORDER = "/order";
 

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -1,5 +1,6 @@
 import axios, { Method } from "axios";
 import { FilterParams, TradeParams } from "src/types";
+import { OpenOrdersParams } from "../types";
 
 export const GET = "GET";
 export const POST = "POST";
@@ -88,6 +89,23 @@ export const addFilterParamsToUrl = (baseUrl: string, params?: FilterParams): st
         }
         if (params.endTs !== undefined) {
             url = buildQueryParams(url, "endTs", `${params.endTs}`);
+        }
+    }
+    return url;
+};
+
+export const addOpenOrderParamsToUrl = (baseUrl: string, params?: OpenOrdersParams): string => {
+    let url = baseUrl;
+    if (params !== undefined) {
+        url = `${url}?`;
+        if (params.market !== undefined) {
+            url = buildQueryParams(url, "market", params.market);
+        }
+        if (params.owner !== undefined) {
+            url = buildQueryParams(url, "owner", params.owner);
+        }
+        if (params.id !== undefined) {
+            url = buildQueryParams(url, "id", params.id as string);
         }
     }
     return url;

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,9 +101,20 @@ export interface Order {
     tokenID: string;
 }
 
-export interface OpenOrdersResponse {
-    orders: Order[];
+export interface OpenOrder {
+    associate_trades: null | Trade[];
+    id: string;
+    market: string;
+    original_size: string;
+    outcome: string;
+    outcome_index: number;
+    owner: string;
+    price: string;
+    side: string;
+    size_matched: string;
 }
+
+export type OpenOrdersResponse = OpenOrder[];
 
 export interface FilterParams {
     market?: string;
@@ -120,6 +131,12 @@ export interface TradeParams {
     limit?: number;
     before?: string;
     after?: string;
+}
+
+export interface OpenOrdersParams {
+    market: string;
+    owner: string;
+    id?: string;
 }
 
 export interface Trade {

--- a/tests/http-helpers/index.test.ts
+++ b/tests/http-helpers/index.test.ts
@@ -4,8 +4,10 @@ import {
     buildQueryParams,
     addFilterParamsToUrl,
     addTradeParamsToUrl,
+    addOpenOrderParamsToUrl,
 } from "../../src/http-helpers/index";
 import { TradeParams } from "../../src";
+import { OpenOrdersParams } from "../../dist/types";
 
 describe("utilities", () => {
     describe("buildQueryParams", () => {
@@ -41,7 +43,7 @@ describe("utilities", () => {
         });
     });
 
-    describe("addFilterParamsToUrl", () => {
+    describe("addTradeParamsToUrl", () => {
         it("checking url + params", () => {
             const url = addTradeParamsToUrl("http://tracker", {
                 market: "10000",
@@ -58,6 +60,20 @@ describe("utilities", () => {
             expect(url).equal(
                 "http://tracker?market=10000&maker=0x2&taker=0x1&id=1&limit=5&before=200&after=100",
             );
+        });
+    });
+
+    describe("addOpenOrderParamsToUrl", () => {
+        it("checking url + params", () => {
+            const url = addOpenOrderParamsToUrl("http://tracker", {
+                market: "10000",
+                owner: "0x69",
+                id: "1",
+            } as OpenOrdersParams);
+            expect(url).not.null;
+            expect(url).not.undefined;
+            expect(url).not.empty;
+            expect(url).equal("http://tracker?market=10000&owner=0x69&id=1");
         });
     });
 });


### PR DESCRIPTION
Implements [this](https://www.notion.so/polymarket/CLOB-API-Refactor-Spec-CLEAN-04a96843a8b74584b0d2069648f6cd77#47a308a57f694408b5738f60aca58e80) refactor into the clob-client: 

One thing to note; I don't see a timestamp in the response, would be useful to sort orders by newest!