### PR TITLE
fix/error-payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.1.18",
+    "version": "1.1.19",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -24,7 +24,7 @@ export const request = async (
                 statusText: err.response?.statusText,
                 data: err.response?.data,
             });
-            return { error: err.response?.data };
+            return err.response?.data;
         }
         console.error(err);
 


### PR DESCRIPTION
New errors payload

```js
{
  error: "order couldn't be fully filled. FOK orders are fully filled or killed."
}
```