### PR TITLE
Feat/add creation time to open orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.1.19",
+    "version": "1.1.20",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export interface OpenOrder {
     associate_trades: Trade[];
     outcome: string;
     outcome_index: number;
+    created_at: number;
 }
 
 export type OpenOrdersResponse = OpenOrder[];


### PR DESCRIPTION
Adding a new field named `created_at` to `OpenOrder` type that represents the order creation timestamp