### PR TITLE
Feat/ adding orderbook summary hash support

### DIFF
--- a/examples/getOrderbook.ts
+++ b/examples/getOrderbook.ts
@@ -8,22 +8,13 @@ async function main() {
     const host = process.env.CLOB_API_URL || "http://localhost:8080";
     const chainId = parseInt(`${process.env.CHAIN_ID || Chain.MUMBAI}`) as Chain;
     const clobClient = new ClobClient(host, chainId);
-    console.log(
-        await clobClient.getOrderBook(
-            "16678291189211314787145083999015737376658799626183230671758641503291735614088", // NO
-        ),
-    );
-    console.log(
-        await clobClient.getOrderBook(
-            "1343197538147866997676250008839231694243646439454152539053893078719042421992", // YES
-        ),
-    );
-    /*
-    {
-        asks: [ { price: '0.60', size: '100', side: 'sell' } ],
-        bids: [ { price: '0.40', size: '100', side: 'buy' } ]
-    }
-    */
+    const YES = "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+
+    const orderbook = await clobClient.getOrderBook(YES);
+    console.log("orderbook", orderbook);
+
+    const hash = clobClient.getOrderBookHash(orderbook);
+    console.log("orderbook hash", hash);
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.1.20",
+    "version": "1.2.0",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
     OpenOrdersResponse,
     OptionalParams,
     Order,
+    OrderBookSummary,
     OrderPayload,
     OrderType,
     Side,
@@ -32,7 +33,7 @@ import {
     post,
 } from "./http-helpers";
 import { L1_AUTH_UNAVAILABLE_ERROR, L2_AUTH_NOT_AVAILABLE } from "./errors";
-import { orderToJson } from "./utilities";
+import { generateOrderBookSummaryHash, orderToJson } from "./utilities";
 import {
     CANCEL_ALL,
     CANCEL_ORDER,
@@ -111,8 +112,17 @@ export class ClobClient {
         return get(`${this.host}${GET_MARKET}${conditionID}`);
     }
 
-    public async getOrderBook(tokenID: string): Promise<any> {
+    public async getOrderBook(tokenID: string): Promise<OrderBookSummary> {
         return get(`${this.host}${GET_ORDER_BOOK}?token_id=${tokenID}`);
+    }
+
+    /**
+     * Calculates the hash for the given orderbook
+     * @param orderbook
+     * @returns
+     */
+    public getOrderBookHash(orderbook: OrderBookSummary): string {
+        return generateOrderBookSummaryHash(orderbook);
     }
 
     public async getMidpoint(tokenID: string): Promise<any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,3 +261,16 @@ export interface MarketPrice {
     v: string; // volume
     ps: string; // positions
 }
+
+export interface OrderBookSummary {
+    market: string;
+    asset_id: string;
+    bids: OrderSummary[];
+    asks: OrderSummary[];
+    hash: string;
+}
+
+export interface OrderSummary {
+    price: string;
+    size: string;
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,6 @@
 import { Side as UtilsSide, SignedOrder } from "@polymarket/order-utils";
-import { NewOrder, OrderType, Side } from "./types";
+import { createHash } from "crypto";
+import { NewOrder, OrderBookSummary, OrderType, Side } from "./types";
 
 export const orderToJson = (order: SignedOrder, owner: string, orderType: OrderType): NewOrder => {
     let side = Side.BUY;
@@ -52,4 +53,16 @@ export const decimalPlaces = (num: number): number => {
     }
 
     return arr[1].length;
+};
+
+/**
+ * Calculates the hash for the given orderbook
+ * @param orderbook
+ * @returns
+ */
+export const generateOrderBookSummaryHash = (orderbook: OrderBookSummary): string => {
+    orderbook.hash = "";
+    const hash = createHash("sha1").update(JSON.stringify(orderbook)).digest("hex");
+    orderbook.hash = hash;
+    return hash;
 };

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -1,8 +1,8 @@
 import "mocha";
 import { expect } from "chai";
-import { decimalPlaces, orderToJson } from "../src/utilities";
+import { decimalPlaces, generateOrderBookSummaryHash, orderToJson } from "../src/utilities";
 import { Side as UtilsSide, SignatureType } from "@polymarket/order-utils";
-import { Chain, OrderType, Side, UserMarketOrder, UserOrder } from "../src";
+import { Chain, OrderBookSummary, OrderType, Side, UserMarketOrder, UserOrder } from "../src";
 import { Wallet } from "@ethersproject/wallet";
 import { createMarketBuyOrder, createOrder } from "../src/order-builder/helpers";
 
@@ -515,5 +515,60 @@ describe("utilities", () => {
     it("decimalPlaces", () => {
         expect(decimalPlaces(949.9970999999999)).to.equal(13);
         expect(decimalPlaces(949)).to.equal(0);
+    });
+
+    it("generateOrderBookSummaryHash", () => {
+        let orderbook = {
+            market: "0xaabbcc",
+            asset_id: "100",
+            bids: [
+                { price: "0.3", size: "100" },
+                { price: "0.4", size: "100" },
+            ],
+            asks: [
+                { price: "0.6", size: "100" },
+                { price: "0.7", size: "100" },
+            ],
+            hash: "",
+        } as OrderBookSummary;
+
+        expect(generateOrderBookSummaryHash(orderbook)).to.equal(
+            "b8b72c72c6534d1b3a4e7fb47b81672d0e94d5a5",
+        );
+        expect(orderbook.hash).to.equal("b8b72c72c6534d1b3a4e7fb47b81672d0e94d5a5");
+
+        // -
+        orderbook = {
+            market: "0xaabbcc",
+            asset_id: "100",
+            bids: [
+                { price: "0.3", size: "100" },
+                { price: "0.4", size: "100" },
+            ],
+            asks: [
+                { price: "0.6", size: "100" },
+                { price: "0.7", size: "100" },
+            ],
+            hash: "b8b72c72c6534d1b3a4e7fb47b81672d0e94d5a5",
+        } as OrderBookSummary;
+
+        expect(generateOrderBookSummaryHash(orderbook)).to.equal(
+            "b8b72c72c6534d1b3a4e7fb47b81672d0e94d5a5",
+        );
+        expect(orderbook.hash).to.equal("b8b72c72c6534d1b3a4e7fb47b81672d0e94d5a5");
+
+        // -
+        orderbook = {
+            market: "0xaabbcc",
+            asset_id: "100",
+            bids: [],
+            asks: [],
+            hash: "",
+        } as OrderBookSummary;
+
+        expect(generateOrderBookSummaryHash(orderbook)).to.equal(
+            "7f81a35a09e1933a96b05edb51ac4be4a6163146",
+        );
+        expect(orderbook.hash).to.equal("7f81a35a09e1933a96b05edb51ac4be4a6163146");
     });
 });


### PR DESCRIPTION
This PR aims to add the orderbook summary struct type and to provide a helper to calculate the hash of an orderbook.

To generate the hash of an orderbook it is needed a `OrderBookSummary` object.

This can be fetched from CLOB:

```ts
const orderbook = await clobClient.getOrderBook("token id" )
```

Or built manually:

```ts
const orderbook = {
     market: "0x...",
     asset_id: "123...",
     bids: [],
     asks: [],
} as OrderBookSummary;
```

Then to generate the hash (if we pull the orderbook from clob the hash is included in the response) there are two options

```ts
// using the client
let hash = clobClient.getOrderBookHash(orderbook);

// or using the util func
import { generateOrderBookSummaryHash } from "@polymarket/clob-client/utilities";

hash = generateOrderBookSummaryHash(orderbook)
```