### PR TITLE
Feat/ New order type: GTD

### DIFF
--- a/examples/GTDOrder.ts
+++ b/examples/GTDOrder.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { config as dotenvConfig } from "dotenv";
 import { resolve } from "path";
-import { ApiKeyCreds, Chain, ClobClient, Side } from "../src";
+import { ApiKeyCreds, Chain, ClobClient, OrderType, Side } from "../src";
 
 dotenvConfig({ path: resolve(__dirname, "../.env") });
 
@@ -18,21 +18,22 @@ async function main() {
     };
     const clobClient = new ClobClient(host, chainId, wallet, creds);
 
-    // Create a buy order for 100 YES for 0.50c
+    // Create a buy order for 100 YES for 0.50c with an expiration of 1 minute
+    // We add an extra 10s because Clob has a security threshold of 10 seconds before canceling it.
     const YES = "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+    const oneMinute = parseInt(((new Date().getTime() + 60 * 1000 + 10 * 1000) / 1000).toString());
+
     const order = await clobClient.createOrder({
         tokenID: YES,
         price: 0.5,
         side: Side.SELL,
-        size: 100,
-        feeRateBps: 0,
-        nonce: 0,
-        expiration: 0,
+        size: 1000,
+        expiration: oneMinute,
     });
     console.log("Created Order", order);
 
     // Send it to the server
-    const resp = await clobClient.postOrder(order);
+    const resp = await clobClient.postOrder(order, OrderType.GTD);
     console.log(resp);
 }
 

--- a/examples/socketConnection.ts
+++ b/examples/socketConnection.ts
@@ -41,7 +41,14 @@ async function main(type: "user" | "market") {
         // subscriptionMessage["assets_ids"] = [NO_TOKEN_ID];
     }
 
-    ws.send(JSON.stringify(subscriptionMessage)); // send sub message
+    ws.on("open", function (ev: any) {
+        ws.send(JSON.stringify(subscriptionMessage)); // send sub message
+
+        setInterval(() => {
+            console.log("PINGING");
+            ws.send("PING");
+        }, 50000);
+    });
 
     ws.onmessage = function (msg: any) {
         console.log(msg.data);
@@ -50,11 +57,6 @@ async function main(type: "user" | "market") {
     ws.on("close", function (ev: any) {
         console.log("disconnected SOCKET - PORT : 5000, reason: " + ev);
     });
-
-    setInterval(() => {
-        console.log("PINGING");
-        ws.send("PING");
-    }, 50000);
 }
 
-main("user");
+main("market");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.2.4",
+    "version": "1.3.0",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/client.ts
+++ b/src/client.ts
@@ -376,9 +376,9 @@ export class ClobClient {
         return get(url, headers);
     }
 
-    public async postOrder(
+    public async postOrder<T extends OrderType = OrderType.GTC>(
         order: SignedOrder,
-        orderType: OrderType = OrderType.GTC,
+        orderType: T = OrderType.GTC as T,
         optionalParams?: OptionalParams,
     ): Promise<any> {
         this.canL2Auth();

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -16,13 +16,16 @@ const overloadHeaders = (method: Method, headers?: Record<string, string | numbe
     if (!headers || typeof headers === undefined) {
         headers = {};
     }
-    headers!["User-Agent"] = `@polymarket/clob-client`;
-    headers!["Accept"] = "*/*";
-    headers!["Connection"] = "keep-alive";
-    headers!["Content-Type"] = "application/json";
 
-    if (method === GET) {
-        headers!["Accept-Encoding"] = "gzip";
+    if (headers) {
+        headers["User-Agent"] = `@polymarket/clob-client`;
+        headers["Accept"] = "*/*";
+        headers["Connection"] = "keep-alive";
+        headers["Content-Type"] = "application/json";
+
+        if (method === GET) {
+            headers["Accept-Encoding"] = "gzip";
+        }
     }
 };
 

--- a/src/order-builder/helpers.ts
+++ b/src/order-builder/helpers.ts
@@ -1,6 +1,6 @@
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
-import { parseUnits } from "ethers/lib/utils";
+import { parseUnits } from "@ethersproject/units";
 import {
     ExchangeOrderBuilder,
     getContracts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,9 +37,10 @@ export enum Side {
 export enum OrderType {
     GTC = "GTC",
     FOK = "FOK",
+    GTD = "GTD",
 }
 
-export interface NewOrder {
+export interface NewOrder<T extends OrderType> {
     readonly order: {
         readonly salt: number;
         readonly maker: string;
@@ -56,7 +57,7 @@ export interface NewOrder {
         readonly signature: string;
     };
     readonly owner: string;
-    readonly orderType: OrderType;
+    readonly orderType: T;
 }
 
 // Simplified order for users

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -2,13 +2,18 @@ import { Side as UtilsSide, SignedOrder } from "@polymarket/order-utils";
 import { createHash } from "crypto";
 import { NewOrder, OrderBookSummary, OrderType, Side } from "./types";
 
-export const orderToJson = (order: SignedOrder, owner: string, orderType: OrderType): NewOrder => {
+export function orderToJson<T extends OrderType>(
+    order: SignedOrder,
+    owner: string,
+    orderType: T,
+): NewOrder<T> {
     let side = Side.BUY;
     if (order.side == UtilsSide.BUY) {
         side = Side.BUY;
     } else {
         side = Side.SELL;
     }
+
     return {
         order: {
             salt: parseInt(order.salt, 10),
@@ -27,8 +32,8 @@ export const orderToJson = (order: SignedOrder, owner: string, orderType: OrderT
         },
         owner,
         orderType,
-    };
-};
+    } as NewOrder<T>;
+}
 
 export const roundNormal = (num: number, decimals: number): number => {
     if (decimalPlaces(num) <= decimals) {

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -1,6 +1,11 @@
 import "mocha";
 import { expect } from "chai";
-import { decimalPlaces, generateOrderBookSummaryHash, orderToJson, roundDown } from "../src/utilities";
+import {
+    decimalPlaces,
+    generateOrderBookSummaryHash,
+    orderToJson,
+    roundDown,
+} from "../src/utilities";
 import { Side as UtilsSide, SignatureType } from "@polymarket/order-utils";
 import { Chain, OrderBookSummary, OrderType, Side, UserMarketOrder, UserOrder } from "../src";
 import { Wallet } from "@ethersproject/wallet";
@@ -8,6 +13,94 @@ import { createMarketBuyOrder, createOrder } from "../src/order-builder/helpers"
 
 describe("utilities", () => {
     describe("orderToJson", () => {
+        it("GTD buy", () => {
+            const jsonOrder = orderToJson(
+                {
+                    salt: "1000",
+                    maker: "0x0000000000000000000000000000000000000001",
+                    signer: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000003",
+                    tokenId: "1",
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: UtilsSide.BUY,
+                    expiration: "0",
+                    nonce: "1",
+                    feeRateBps: "100",
+                    signatureType: SignatureType.POLY_GNOSIS_SAFE,
+                    signature: "0x",
+                },
+                "aaaa-bbbb-cccc-dddd",
+                OrderType.GTD,
+            );
+            expect(jsonOrder).not.null;
+            expect(jsonOrder).not.undefined;
+
+            expect(jsonOrder).deep.equal({
+                order: {
+                    salt: 1000,
+                    maker: "0x0000000000000000000000000000000000000001",
+                    signer: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000003",
+                    tokenId: "1",
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: "BUY",
+                    expiration: "0",
+                    nonce: "1",
+                    feeRateBps: "100",
+                    signatureType: 2,
+                    signature: "0x",
+                },
+                owner: "aaaa-bbbb-cccc-dddd",
+                orderType: "GTD",
+            });
+        });
+
+        it("GTD sell", () => {
+            const jsonOrder = orderToJson(
+                {
+                    salt: "1000",
+                    maker: "0x0000000000000000000000000000000000000001",
+                    signer: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000003",
+                    tokenId: "1",
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: UtilsSide.SELL,
+                    expiration: "0",
+                    nonce: "1",
+                    feeRateBps: "100",
+                    signatureType: SignatureType.POLY_GNOSIS_SAFE,
+                    signature: "0x",
+                },
+                "aaaa-bbbb-cccc-dddd",
+                OrderType.GTD,
+            );
+            expect(jsonOrder).not.null;
+            expect(jsonOrder).not.undefined;
+
+            expect(jsonOrder).deep.equal({
+                order: {
+                    salt: 1000,
+                    maker: "0x0000000000000000000000000000000000000001",
+                    signer: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000003",
+                    tokenId: "1",
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: "SELL",
+                    expiration: "0",
+                    nonce: "1",
+                    feeRateBps: "100",
+                    signatureType: 2,
+                    signature: "0x",
+                },
+                owner: "aaaa-bbbb-cccc-dddd",
+                orderType: "GTD",
+            });
+        });
+
         it("GTC buy", () => {
             const jsonOrder = orderToJson(
                 {
@@ -150,12 +243,13 @@ describe("utilities", () => {
             const chainId = Chain.MUMBAI;
             const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
 
-            // GTC BUY EOA
+            // GTD BUY EOA
             let userOrder: UserOrder = {
                 tokenID: token,
                 price: 0.5,
                 side: Side.BUY,
                 size: 100,
+                expiration: 1709948026,
             };
             let signedOrder = await createOrder(
                 wallet,
@@ -167,11 +261,250 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            let jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            let jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "50000000",
+                    takerAmount: "100000000",
+                    side: "BUY",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 0,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTD BUY POLY_PROXY
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.BUY,
+                size: 100,
+                expiration: 1709948026,
+            };
+            signedOrder = await createOrder(
+                wallet,
+                chainId,
+                SignatureType.POLY_PROXY,
+                address,
+                userOrder,
+            );
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
+
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "50000000",
+                    takerAmount: "100000000",
+                    side: "BUY",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 1,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTD BUY POLY_GNOSIS_SAFE
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.BUY,
+                size: 100,
+                expiration: 1709948026,
+            };
+            signedOrder = await createOrder(
+                wallet,
+                chainId,
+                SignatureType.POLY_GNOSIS_SAFE,
+                address,
+                userOrder,
+            );
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
+
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "50000000",
+                    takerAmount: "100000000",
+                    side: "BUY",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 2,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTD SELL EOA
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.SELL,
+                size: 100,
+                expiration: 1709948026,
+            };
+            signedOrder = await createOrder(wallet, chainId, SignatureType.EOA, address, userOrder);
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
+
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: "SELL",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 0,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTD SELL POLY_PROXY
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.SELL,
+                size: 100,
+                expiration: 1709948026,
+            };
+            signedOrder = await createOrder(
+                wallet,
+                chainId,
+                SignatureType.POLY_PROXY,
+                address,
+                userOrder,
+            );
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
+
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: "SELL",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 1,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTD SELL POLY_GNOSIS_SAFE
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.SELL,
+                size: 100,
+                expiration: 1709948026,
+            };
+            signedOrder = await createOrder(
+                wallet,
+                chainId,
+                SignatureType.POLY_GNOSIS_SAFE,
+                address,
+                userOrder,
+            );
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+            expect(jsonGTDOrder).not.null;
+            expect(jsonGTDOrder).not.undefined;
+
+            expect(jsonGTDOrder).deep.equal({
+                order: {
+                    salt: parseInt(signedOrder.salt),
+                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: token,
+                    makerAmount: "100000000",
+                    takerAmount: "50000000",
+                    side: "SELL",
+                    expiration: "1709948026",
+                    nonce: "0",
+                    feeRateBps: "0",
+                    signatureType: 2,
+                    signature: signedOrder.signature,
+                },
+                owner: owner,
+                orderType: OrderType.GTD,
+            });
+
+            // GTC BUY EOA
+            userOrder = {
+                tokenID: token,
+                price: 0.5,
+                side: Side.BUY,
+                size: 100,
+            };
+            signedOrder = await createOrder(wallet, chainId, SignatureType.EOA, address, userOrder);
+            expect(signedOrder).not.null;
+            expect(signedOrder).not.undefined;
+
+            let jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
+
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -208,11 +541,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -249,11 +582,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -284,11 +617,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -325,11 +658,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -366,11 +699,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+            expect(jsonGTCOrder).not.null;
+            expect(jsonGTCOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonGTCOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -406,11 +739,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            let jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+            expect(jsonFOKOrder).not.null;
+            expect(jsonFOKOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonFOKOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -446,11 +779,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+            expect(jsonFOKOrder).not.null;
+            expect(jsonFOKOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonFOKOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -486,11 +819,11 @@ describe("utilities", () => {
             expect(signedOrder).not.null;
             expect(signedOrder).not.undefined;
 
-            jsonOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonOrder).not.null;
-            expect(jsonOrder).not.undefined;
+            jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+            expect(jsonFOKOrder).not.null;
+            expect(jsonFOKOrder).not.undefined;
 
-            expect(jsonOrder).deep.equal({
+            expect(jsonFOKOrder).deep.equal({
                 order: {
                     salt: parseInt(signedOrder.salt),
                     maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -525,7 +858,7 @@ describe("utilities", () => {
         expect(roundDown(0.55, 4)).to.equal(0.55);
         expect(roundDown(0.56, 4)).to.equal(0.56);
         expect(roundDown(0.57, 4)).to.equal(0.57);
-	});
+    });
 
     it("generateOrderBookSummaryHash", () => {
         let orderbook = {


### PR DESCRIPTION
This PR includes a new type of order: `GTD`.

The `GTD` orders have the ability to expire when the time expressed in its field called `expiration` arrives.

The timestamp must be expressed in UNIX timestamp (seconds) using the `UTC` location.

### Security threshold

As the Clob needs some time to process, match and submit a trade, there is a security threshold for GTD orders. This value is `10s` (10 seconds).

So when an order is about 10 seconds from its expiration timestamp, the Clob will expire it.

For example, if we need a `1m` expiration order we should use a timestamp that represents this: `UTC NOW + 1m + 10s`.
