### PR TITLE
feat/ adding expiration to open orders endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,6 @@ import {
     OpenOrderParams,
     OpenOrdersResponse,
     OptionalParams,
-    Order,
     OrderMarketCancelParams,
     OrderBookSummary,
     OrderPayload,
@@ -26,6 +25,7 @@ import {
     BalanceAllowanceResponse,
     OrderScoringParams,
     OrderScoring,
+    OpenOrder,
 } from "./types";
 import { createL1Headers, createL2Headers } from "./headers";
 import {
@@ -246,7 +246,7 @@ export class ClobClient {
         return del(`${this.host}${endpoint}`, headers);
     }
 
-    public async getOrder(orderID: string): Promise<Order> {
+    public async getOrder(orderID: string): Promise<OpenOrder> {
         this.canL2Auth();
 
         const endpoint = `${GET_ORDER}${orderID}`;

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -43,14 +43,17 @@ export const request = async (
         return response;
     } catch (err) {
         if (axios.isAxiosError(err)) {
-            console.error("request error", {
-                status: err.response?.status,
-                statusText: err.response?.statusText,
-                data: err.response?.data,
-            });
-            return err.response?.data;
+            if (err.response) {
+                console.error("request error", {
+                    status: err.response?.status,
+                    statusText: err.response?.statusText,
+                    data: err.response?.data,
+                });
+                return err.response?.data;
+            } else {
+                return { error: "connection error" };
+            }
         }
-        console.error(err);
 
         return { error: err };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,21 +158,9 @@ export interface OrderResponse {
     status: string;
 }
 
-// get order/{orderID} response
-export interface Order {
-    orderID: string;
-    owner: string;
-    timestamp: string;
-    price: string;
-    size: string;
-    available_size: string;
-    side: string;
-    status: string;
-    asset_id: string;
-}
-
 export interface OpenOrder {
     id: string;
+    status: string;
     owner: string;
     market: string;
     asset_id: string;
@@ -184,6 +172,7 @@ export interface OpenOrder {
     outcome: string;
     outcome_index: number;
     created_at: number;
+    type: string;
 }
 
 export type OpenOrdersResponse = OpenOrder[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,7 @@ export interface OpenOrder {
     outcome: string;
     outcome_index: number;
     created_at: number;
+    expiration: string;
     type: string;
 }
 


### PR DESCRIPTION
This PR adds two new fields to the `OpenOrder` structure:
- `expiration`: `string`, unix timestamp when the order expired, 0 if it does not expire
- `type`: `string`, order type (GTC, FOK, GTD).

### Complete `OpenOrder` data type:

```typescript
export interface OpenOrder {
    id: string;
    status: string;
    owner: string;
    market: string;
    asset_id: string;
    side: string;
    original_size: string;
    size_matched: string;
    price: string;
    associate_trades: Trade[];
    outcome: string;
    outcome_index: number;
    created_at: number;
    type: string;
}
```