### PR TITLE
feat/ adding support for all the possible tick sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 		--require jsdom-global/register \
 		--require ts-node/register 'tests/**/*.test.ts' \
 		--require tsconfig-paths/register \
-		--timeout 30000 \
+		--timeout 300000 \
 		--exit
 
 .PHONY: lint

--- a/examples/order.ts
+++ b/examples/order.ts
@@ -20,15 +20,18 @@ async function main() {
 
     // Create a buy order for 100 YES for 0.50c
     const YES = "1343197538147866997676250008839231694243646439454152539053893078719042421992";
-    const order = await clobClient.createOrder({
-        tokenID: YES,
-        price: 0.5,
-        side: Side.SELL,
-        size: 100,
-        feeRateBps: 0,
-        nonce: 0,
-        expiration: 0,
-    });
+    const order = await clobClient.createOrder(
+        {
+            tokenID: YES,
+            price: 0.05,
+            side: Side.SELL,
+            size: 100,
+            feeRateBps: 0,
+            nonce: 0,
+            expiration: 0,
+        },
+        "0.01",
+    );
     console.log("Created Order", order);
 
     // Send it to the server

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.6.0",
+    "version": "2.1.0",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -14,6 +14,7 @@ export const GET_ORDER_BOOK = "/book";
 export const GET_MIDPOINT = "/midpoint";
 export const GET_PRICE = "/price";
 export const GET_LAST_TRADE_PRICE = "/last-trade-price";
+export const GET_TICK_SIZE = "/tick-size";
 
 // Order endpoints
 export const POST_ORDER = "/order";

--- a/src/order-builder/builder.ts
+++ b/src/order-builder/builder.ts
@@ -2,7 +2,7 @@ import { Wallet } from "@ethersproject/wallet";
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { SignedOrder, SignatureType } from "@polymarket/order-utils";
 import { createMarketBuyOrder, createOrder } from "./helpers";
-import { Chain, UserMarketOrder, UserOrder } from "../types";
+import { Chain, TickSize, UserMarketOrder, UserOrder } from "../types";
 
 export class OrderBuilder {
     readonly signer: Wallet | JsonRpcSigner;
@@ -32,26 +32,31 @@ export class OrderBuilder {
     /**
      * Generate and sign a order
      */
-    public async buildOrder(userOrder: UserOrder): Promise<SignedOrder> {
+    public async buildOrder(userOrder: UserOrder, tickSize: TickSize): Promise<SignedOrder> {
         return createOrder(
             this.signer,
             this.chainId,
             this.signatureType,
             this.funderAddress,
             userOrder,
+            tickSize,
         );
     }
 
     /**
      * Generate and sign a market order
      */
-    public async buildMarketOrder(userMarketOrder: UserMarketOrder): Promise<SignedOrder> {
+    public async buildMarketOrder(
+        userMarketOrder: UserMarketOrder,
+        tickSize: TickSize,
+    ): Promise<SignedOrder> {
         return createMarketBuyOrder(
             this.signer,
             this.chainId,
             this.signatureType,
             this.funderAddress,
             userMarketOrder,
+            tickSize,
         );
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,3 +319,15 @@ export interface OrderScoringParams {
 export interface OrderScoring {
     scoring: boolean;
 }
+
+export type TickSize = "0.1" | "0.01" | "0.001" | "0.0001";
+
+export interface RoundConfig {
+    readonly price: number;
+    readonly size: number;
+    readonly amount: number;
+}
+
+export interface TickSizes {
+    [tokenId: string]: TickSize;
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,6 @@
 import { Side as UtilsSide, SignedOrder } from "@polymarket/order-utils";
 import { createHash } from "crypto";
-import { NewOrder, OrderBookSummary, OrderType, Side } from "./types";
+import { NewOrder, OrderBookSummary, OrderType, Side, TickSize } from "./types";
 
 export function orderToJson<T extends OrderType>(
     order: SignedOrder,
@@ -79,4 +79,8 @@ export const generateOrderBookSummaryHash = (orderbook: OrderBookSummary): strin
     const hash = createHash("sha1").update(JSON.stringify(orderbook)).digest("hex");
     orderbook.hash = hash;
     return hash;
+};
+
+export const isTickSizeSmaller = (a: TickSize, b: TickSize): boolean => {
+    return parseFloat(a) < parseFloat(b);
 };

--- a/tests/order-builder/helpers.test.ts
+++ b/tests/order-builder/helpers.test.ts
@@ -7,8 +7,9 @@ import {
     createOrder,
     buildMarketBuyOrderCreationArgs,
     createMarketBuyOrder,
-    getOrderAmounts,
+    getOrderRawAmounts,
     getMarketBuyOrderRawAmounts,
+    ROUNDING_CONFIG,
 } from "../../src/order-builder/helpers";
 import {
     OrderData,
@@ -32,731 +33,3171 @@ describe("helpers", () => {
     });
 
     describe("buildOrder", () => {
-        it("buy order", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.56,
-                size: 21.04,
-                side: Side.BUY,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-                taker: "0x0000000000000000000000000000000000000003",
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData).not.null;
-            expect(orderData).not.undefined;
+        describe("buy order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
 
-            const signedOrder = await buildOrder(wallet, contracts.Exchange, chainId, orderData);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
-            expect(signedOrder.tokenId).equal("123");
-            expect(signedOrder.makerAmount).equal("11782400");
-            expect(signedOrder.takerAmount).equal("21040000");
-            expect(signedOrder.side).equal(UtilsSide.BUY);
-            expect(signedOrder.expiration).equal("50000");
-            expect(signedOrder.nonce).equal("123");
-            expect(signedOrder.feeRateBps).equal("111");
-            expect(signedOrder.signatureType).equal(SignatureType.EOA);
-            expect(signedOrder.signature).not.empty;
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("10520000");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("11782400");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.001"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("1178240");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.0001"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("117824");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("precision", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.82,
+                    size: 20.0,
+                    side: Side.BUY,
+                    feeRateBps: 0,
+                    nonce: 123,
+                    expiration: 50000,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("16400000");
+                expect(signedOrder.takerAmount).equal("20000000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
         });
 
-        it("buy order precision", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.82,
-                size: 20.0,
-                side: Side.BUY,
-                feeRateBps: 0,
-                nonce: 123,
-                expiration: 50000,
-                taker: "0x0000000000000000000000000000000000000003",
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData).not.null;
-            expect(orderData).not.undefined;
+        describe("sell order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.1"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
 
-            const signedOrder = await buildOrder(wallet, contracts.Exchange, chainId, orderData);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
-            expect(signedOrder.tokenId).equal("123");
-            expect(signedOrder.makerAmount).equal("16400000");
-            expect(signedOrder.takerAmount).equal("20000000");
-            expect(signedOrder.side).equal(UtilsSide.BUY);
-            expect(signedOrder.expiration).equal("50000");
-            expect(signedOrder.nonce).equal("123");
-            expect(signedOrder.feeRateBps).equal("0");
-            expect(signedOrder.signatureType).equal(SignatureType.EOA);
-            expect(signedOrder.signature).not.empty;
-        });
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("10520000");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_PROXY);
+                expect(signedOrder.signature).not.empty;
+            });
 
-        it("sell order", async () => {
-            const order: UserOrder = {
-                tokenID: "5",
-                price: 0.56,
-                size: 21.04,
-                side: Side.SELL,
-                feeRateBps: 0,
-                nonce: 0,
-                taker: "0x0000000000000000000000000000000000000003",
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                SignatureType.POLY_PROXY,
-                order,
-            );
-            expect(orderData).not.null;
-            expect(orderData).not.undefined;
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
 
-            const signedOrder = await buildOrder(wallet, contracts.Exchange, chainId, orderData);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
-            expect(signedOrder.tokenId).equal("5");
-            expect(signedOrder.makerAmount).equal("21040000");
-            expect(signedOrder.takerAmount).equal("11782400");
-            expect(signedOrder.side).equal(UtilsSide.SELL);
-            expect(signedOrder.expiration).equal("0");
-            expect(signedOrder.nonce).equal("0");
-            expect(signedOrder.feeRateBps).equal("0");
-            expect(signedOrder.signatureType).equal(SignatureType.POLY_PROXY);
-            expect(signedOrder.signature).not.empty;
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("11782400");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_PROXY);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.001"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("1178240");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_PROXY);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x0000000000000000000000000000000000000003",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.0001"],
+                );
+                expect(orderData).not.null;
+                expect(orderData).not.undefined;
+
+                const signedOrder = await buildOrder(
+                    wallet,
+                    contracts.Exchange,
+                    chainId,
+                    orderData,
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000003");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("117824");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_PROXY);
+                expect(signedOrder.signature).not.empty;
+            });
         });
     });
 
-    describe("getOrderAmounts", async () => {
-        it("buy", async () => {
-            const delta = 0.01;
-            let size = 0.01;
+    describe("getOrderRawAmounts", async () => {
+        describe("buy", async () => {
+            it("0.1", async () => {
+                const delta_price = 0.1;
+                const delta_size = 0.01;
+                let size = 0.01;
 
-            for (; size <= 100; ) {
-                let price = 0.01;
-                for (; price <= 1; ) {
-                    const { rawMakerAmt, rawTakerAmt } = getOrderAmounts(Side.BUY, size, price);
+                for (; size <= 1000; ) {
+                    let price = 0.1;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.BUY,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.1"],
+                        );
 
-                    expect(decimalPlaces(rawMakerAmt)).to.lte(4);
-                    expect(decimalPlaces(rawTakerAmt)).to.lte(2);
-                    expect(roundNormal(rawMakerAmt / rawTakerAmt, 6)).to.gte(roundNormal(price, 6));
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(3);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(2);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 2)).to.gte(
+                            roundNormal(price, 2),
+                        );
 
-                    price += delta;
+                        price += delta_price;
+                    }
+                    size += delta_size;
                 }
-                size += delta;
-            }
+            });
+
+            it("0.01", async () => {
+                const delta_price = 0.01;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 100; ) {
+                    let price = 0.01;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.BUY,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.01"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(4);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(2);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 4)).to.gte(
+                            roundNormal(price, 4),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.001", async () => {
+                const delta_price = 0.001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 10; ) {
+                    let price = 0.001;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.BUY,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(5);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(2);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 6)).to.gte(
+                            roundNormal(price, 6),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.0001", async () => {
+                const delta_price = 0.0001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 1; ) {
+                    let price = 0.0001;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.BUY,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.0001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(6);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(2);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 8)).to.gte(
+                            roundNormal(price, 8),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
         });
 
-        it("sell", async () => {
-            const delta = 0.01;
-            let size = 0.01;
+        describe("sell", async () => {
+            it("0.1", async () => {
+                const delta_price = 0.1;
+                const delta_size = 0.01;
+                let size = 0.01;
 
-            for (; size <= 100; ) {
-                let price = 0.01;
-                for (; price <= 1; ) {
-                    const { rawMakerAmt, rawTakerAmt } = getOrderAmounts(Side.SELL, size, price);
+                for (; size <= 1000; ) {
+                    let price = 0.1;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.SELL,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.1"],
+                        );
 
-                    expect(decimalPlaces(rawMakerAmt)).to.lte(2);
-                    expect(decimalPlaces(rawTakerAmt)).to.lte(4);
-                    expect(roundNormal(rawTakerAmt / rawMakerAmt, 6)).to.lte(roundNormal(price, 6));
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(3);
+                        expect(roundNormal(rawTakerAmt / rawMakerAmt, 2)).to.lte(
+                            roundNormal(price, 2),
+                        );
 
-                    price += delta;
+                        price += delta_price;
+                    }
+                    size += delta_size;
                 }
-                size += delta;
-            }
+            });
+
+            it("0.01", async () => {
+                const delta_price = 0.01;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 100; ) {
+                    let price = 0.01;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.SELL,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.01"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(4);
+                        expect(roundNormal(rawTakerAmt / rawMakerAmt, 4)).to.lte(
+                            roundNormal(price, 4),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.001", async () => {
+                const delta_price = 0.001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 10; ) {
+                    let price = 0.001;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.SELL,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(5);
+                        expect(roundNormal(rawTakerAmt / rawMakerAmt, 6)).to.lte(
+                            roundNormal(price, 6),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.0001", async () => {
+                const delta_price = 0.0001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 1; ) {
+                    let price = 0.0001;
+                    for (; price <= 1; ) {
+                        const { rawMakerAmt, rawTakerAmt } = getOrderRawAmounts(
+                            Side.SELL,
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.0001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(6);
+                        expect(roundNormal(rawTakerAmt / rawMakerAmt, 8)).to.lte(
+                            roundNormal(price, 8),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
         });
     });
 
     describe("buildOrderCreationArgs", () => {
-        it("buy order", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.56,
-                size: 21.04,
-                side: Side.BUY,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "0x0000000000000000000000000000000000000001",
-                "0x0000000000000000000000000000000000000002",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData).deep.equal({
-                maker: "0x0000000000000000000000000000000000000002",
-                taker: "0x0000000000000000000000000000000000000000",
-                tokenId: "123",
-                makerAmount: "11782400",
-                takerAmount: "21040000",
-                side: UtilsSide.BUY,
-                feeRateBps: "111",
-                nonce: "123",
-                signer: "0x0000000000000000000000000000000000000001",
-                expiration: "50000",
-                signatureType: SignatureType.EOA,
+        describe("buy order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.1"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "10520000",
+                    takerAmount: "21040000",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "11782400",
+                    takerAmount: "21040000",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "1178240",
+                    takerAmount: "21040000",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.0001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "117824",
+                    takerAmount: "21040000",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
             });
         });
 
-        it("sell order", async () => {
-            const order: UserOrder = {
-                tokenID: "5",
-                price: 0.56,
-                size: 21.04,
-                side: Side.SELL,
-                feeRateBps: 0,
-                nonce: 0,
-                taker: "0x000000000000000000000000000000000000000A",
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "0x0000000000000000000000000000000000000001",
-                "0x0000000000000000000000000000000000000002",
-                SignatureType.POLY_PROXY,
-                order,
-            );
-            expect(orderData).deep.equal({
-                maker: "0x0000000000000000000000000000000000000002",
-                taker: "0x000000000000000000000000000000000000000A",
-                tokenId: "5",
-                takerAmount: "11782400",
-                makerAmount: "21040000",
-                side: UtilsSide.SELL,
-                feeRateBps: "0",
-                nonce: "0",
-                signer: "0x0000000000000000000000000000000000000001",
-                expiration: "0",
-                signatureType: SignatureType.POLY_PROXY,
+        describe("sell order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x000000000000000000000000000000000000000A",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.1"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x000000000000000000000000000000000000000A",
+                    tokenId: "5",
+                    takerAmount: "10520000",
+                    makerAmount: "21040000",
+                    side: UtilsSide.SELL,
+                    feeRateBps: "0",
+                    nonce: "0",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "0",
+                    signatureType: SignatureType.POLY_PROXY,
+                });
+            });
+
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x000000000000000000000000000000000000000A",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x000000000000000000000000000000000000000A",
+                    tokenId: "5",
+                    takerAmount: "11782400",
+                    makerAmount: "21040000",
+                    side: UtilsSide.SELL,
+                    feeRateBps: "0",
+                    nonce: "0",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "0",
+                    signatureType: SignatureType.POLY_PROXY,
+                });
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x000000000000000000000000000000000000000A",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x000000000000000000000000000000000000000A",
+                    tokenId: "5",
+                    takerAmount: "1178240",
+                    makerAmount: "21040000",
+                    side: UtilsSide.SELL,
+                    feeRateBps: "0",
+                    nonce: "0",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "0",
+                    signatureType: SignatureType.POLY_PROXY,
+                });
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                    taker: "0x000000000000000000000000000000000000000A",
+                };
+                const orderData: OrderData = await buildOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.POLY_PROXY,
+                    order,
+                    ROUNDING_CONFIG["0.0001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x000000000000000000000000000000000000000A",
+                    tokenId: "5",
+                    takerAmount: "117824",
+                    makerAmount: "21040000",
+                    side: UtilsSide.SELL,
+                    feeRateBps: "0",
+                    nonce: "0",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "0",
+                    signatureType: SignatureType.POLY_PROXY,
+                });
             });
         });
 
-        it("correctly rounds price amounts for validity buy", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.56,
-                size: 21.04,
-                side: Side.BUY,
-                feeRateBps: 100,
-                nonce: 0,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.56);
-        });
+        describe("real cases", async () => {
+            describe("0.1", async () => {
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        size: 21.04,
+                        side: Side.BUY,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.5,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 2", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.7,
-                size: 170,
-                side: Side.BUY,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("119000000");
-            expect(orderData.takerAmount).to.equal("170000000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.7);
-        });
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        size: 170,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 3", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.82,
-                size: 101,
-                side: Side.BUY,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("82820000");
-            expect(orderData.takerAmount).to.equal("101000000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.82);
-        });
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.8,
+                        size: 101,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("80800000");
+                    expect(orderData.takerAmount).to.equal("101000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.8,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 4", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                size: 12.8205,
-                price: 0.78,
-                side: Side.BUY,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("9999600");
-            expect(orderData.takerAmount).to.equal("12820000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.78);
-        });
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.7,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("8974000");
+                    expect(orderData.takerAmount).to.equal("12820000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 5", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                size: 2435.89,
-                price: 0.39,
-                side: Side.BUY,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("949997100");
-            expect(orderData.takerAmount).to.equal("2435890000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.39);
-        });
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.3,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("730767000");
+                    expect(orderData.takerAmount).to.equal("2435890000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.3,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity sell", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.56,
-                size: 21.04,
-                side: Side.SELL,
-                feeRateBps: 100,
-                nonce: 0,
-            };
+                it("correctly rounds price amounts for validity sell", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        size: 21.04,
+                        side: Side.SELL,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
 
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.equal(0.56);
-        });
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.equal(
+                        0.5,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity sell - 2", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.7,
-                size: 170,
-                side: Side.SELL,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.takerAmount).to.equal("119000000");
-            expect(orderData.makerAmount).to.equal("170000000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.7);
-        });
+                it("correctly rounds price amounts for validity sell - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        size: 170,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.takerAmount).to.equal("119000000");
+                    expect(orderData.makerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity sell - 3", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.82,
-                size: 101,
-                side: Side.SELL,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("101000000");
-            expect(orderData.takerAmount).to.equal("82820000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.82);
-        });
+                it("correctly rounds price amounts for validity sell - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.8,
+                        size: 101,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("101000000");
+                    expect(orderData.takerAmount).to.equal("80800000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.8,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity sell - 4", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                size: 12.8205,
-                price: 0.78,
-                side: Side.SELL,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("12820000");
-            expect(orderData.takerAmount).to.equal("9999600");
-            expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(0.78);
-        });
+                it("correctly rounds price amounts for validity sell - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.7,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("12820000");
+                    expect(orderData.takerAmount).to.equal("8974000");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.7,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity sell - 5", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                size: 2435.89,
-                price: 0.39,
-                side: Side.SELL,
-            };
-            const orderData: OrderData = await buildOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("2435890000");
-            expect(orderData.takerAmount).to.equal("949997100");
-            expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(0.39);
+                it("correctly rounds price amounts for validity sell - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.3,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("2435890000");
+                    expect(orderData.takerAmount).to.equal("730767000");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.3,
+                    );
+                });
+            });
+
+            describe("0.01", async () => {
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.56,
+                        size: 21.04,
+                        side: Side.BUY,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.56,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        size: 170,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.82,
+                        size: 101,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("82820000");
+                    expect(orderData.takerAmount).to.equal("101000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.82,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.78,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9999600");
+                    expect(orderData.takerAmount).to.equal("12820000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.78,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.39,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("949997100");
+                    expect(orderData.takerAmount).to.equal("2435890000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.39,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.56,
+                        size: 21.04,
+                        side: Side.SELL,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.equal(
+                        0.56,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        size: 170,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.takerAmount).to.equal("119000000");
+                    expect(orderData.makerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.82,
+                        size: 101,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("101000000");
+                    expect(orderData.takerAmount).to.equal("82820000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.82,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.78,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("12820000");
+                    expect(orderData.takerAmount).to.equal("9999600");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.78,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.39,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("2435890000");
+                    expect(orderData.takerAmount).to.equal("949997100");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.39,
+                    );
+                });
+            });
+
+            describe("0.001", async () => {
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.056,
+                        size: 21.04,
+                        side: Side.BUY,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.007,
+                        size: 170,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1190000");
+                    expect(orderData.takerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.082,
+                        size: 101,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("8282000");
+                    expect(orderData.takerAmount).to.equal("101000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.078,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("999960");
+                    expect(orderData.takerAmount).to.equal("12820000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.039,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("94999710");
+                    expect(orderData.takerAmount).to.equal("2435890000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.039,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.056,
+                        size: 21.04,
+                        side: Side.SELL,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.equal(
+                        0.056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.007,
+                        size: 170,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.takerAmount).to.equal("1190000");
+                    expect(orderData.makerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.082,
+                        size: 101,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("101000000");
+                    expect(orderData.takerAmount).to.equal("8282000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.078,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("12820000");
+                    expect(orderData.takerAmount).to.equal("999960");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.039,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("2435890000");
+                    expect(orderData.takerAmount).to.equal("94999710");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.039,
+                    );
+                });
+            });
+
+            describe("0.0001", async () => {
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0056,
+                        size: 21.04,
+                        side: Side.BUY,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0007,
+                        size: 170,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("119000");
+                    expect(orderData.takerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0082,
+                        size: 101,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("828200");
+                    expect(orderData.takerAmount).to.equal("101000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.0078,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("99996");
+                    expect(orderData.takerAmount).to.equal("12820000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.0039,
+                        side: Side.BUY,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9499971");
+                    expect(orderData.takerAmount).to.equal("2435890000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0039,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0056,
+                        size: 21.04,
+                        side: Side.SELL,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.equal(
+                        0.0056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 2", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0007,
+                        size: 170,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.takerAmount).to.equal("119000");
+                    expect(orderData.makerAmount).to.equal("170000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 3", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        price: 0.0082,
+                        size: 101,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("101000000");
+                    expect(orderData.takerAmount).to.equal("828200");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 4", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 12.8205,
+                        price: 0.0078,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("12820000");
+                    expect(orderData.takerAmount).to.equal("99996");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.0078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity sell - 5", async () => {
+                    const order: UserOrder = {
+                        tokenID: "123",
+                        size: 2435.89,
+                        price: 0.0039,
+                        side: Side.SELL,
+                    };
+                    const orderData: OrderData = await buildOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("2435890000");
+                    expect(orderData.takerAmount).to.equal("9499971");
+                    expect(Number(orderData.takerAmount) / Number(orderData.makerAmount)).to.gte(
+                        0.0039,
+                    );
+                });
+            });
         });
     });
 
     describe("createOrder", () => {
-        it("buy order", async () => {
-            const order: UserOrder = {
-                tokenID: "123",
-                price: 0.56,
-                size: 21.04,
-                side: Side.BUY,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-            };
+        describe("buy order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
 
-            const signedOrder = await createOrder(
-                wallet,
-                Chain.MUMBAI,
-                SignatureType.EOA,
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                order,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.1",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
-            expect(signedOrder.tokenId).equal("123");
-            expect(signedOrder.makerAmount).equal("11782400");
-            expect(signedOrder.takerAmount).equal("21040000");
-            expect(signedOrder.side).equal(UtilsSide.BUY);
-            expect(signedOrder.expiration).equal("50000");
-            expect(signedOrder.nonce).equal("123");
-            expect(signedOrder.feeRateBps).equal("111");
-            expect(signedOrder.signatureType).equal(SignatureType.EOA);
-            expect(signedOrder.signature).not.empty;
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("10520000");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.01",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("11782400");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.001",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("1178240");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "123",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.BUY,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.0001",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("117824");
+                expect(signedOrder.takerAmount).equal("21040000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
         });
 
-        it("sell order", async () => {
-            const order: UserOrder = {
-                tokenID: "5",
-                price: 0.56,
-                size: 21.04,
-                side: Side.SELL,
-                feeRateBps: 0,
-                nonce: 0,
-            };
+        describe("sell order", async () => {
+            it("0.1", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.5,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                };
 
-            const signedOrder = await createOrder(
-                wallet,
-                Chain.MUMBAI,
-                SignatureType.POLY_GNOSIS_SAFE,
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                order,
-            );
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.POLY_GNOSIS_SAFE,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.1",
+                );
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
-            expect(signedOrder.tokenId).equal("5");
-            expect(signedOrder.makerAmount).equal("21040000");
-            expect(signedOrder.takerAmount).equal("11782400");
-            expect(signedOrder.side).equal(UtilsSide.SELL);
-            expect(signedOrder.expiration).equal("0");
-            expect(signedOrder.nonce).equal("0");
-            expect(signedOrder.feeRateBps).equal("0");
-            expect(signedOrder.signatureType).equal(SignatureType.POLY_GNOSIS_SAFE);
-            expect(signedOrder.signature).not.empty;
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("10520000");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_GNOSIS_SAFE);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.01", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.56,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.POLY_GNOSIS_SAFE,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.01",
+                );
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("11782400");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_GNOSIS_SAFE);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.POLY_GNOSIS_SAFE,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.001",
+                );
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("1178240");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_GNOSIS_SAFE);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.0001", async () => {
+                const order: UserOrder = {
+                    tokenID: "5",
+                    price: 0.0056,
+                    size: 21.04,
+                    side: Side.SELL,
+                    feeRateBps: 0,
+                    nonce: 0,
+                };
+
+                const signedOrder = await createOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.POLY_GNOSIS_SAFE,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.0001",
+                );
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("5");
+                expect(signedOrder.makerAmount).equal("21040000");
+                expect(signedOrder.takerAmount).equal("117824");
+                expect(signedOrder.side).equal(UtilsSide.SELL);
+                expect(signedOrder.expiration).equal("0");
+                expect(signedOrder.nonce).equal("0");
+                expect(signedOrder.feeRateBps).equal("0");
+                expect(signedOrder.signatureType).equal(SignatureType.POLY_GNOSIS_SAFE);
+                expect(signedOrder.signature).not.empty;
+            });
         });
     });
 
     describe("getMarketBuyOrderRawAmounts", async () => {
-        it("market buy", async () => {
-            const delta = 0.01;
-            let size = 0.01;
+        describe("market buy", async () => {
+            it("0.1", async () => {
+                const delta_price = 0.1;
+                const delta_size = 0.01;
+                let size = 0.01;
 
-            for (; size <= 100; ) {
-                let price = 0.01;
-                for (; price <= 1; ) {
-                    price = roundNormal(price, 8);
-                    const { rawMakerAmt, rawTakerAmt } = getMarketBuyOrderRawAmounts(size, price);
+                for (; size <= 1000; ) {
+                    let price = 0.1;
+                    for (; price <= 1; ) {
+                        price = roundNormal(price, 8);
+                        const { rawMakerAmt, rawTakerAmt } = getMarketBuyOrderRawAmounts(
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.1"],
+                        );
 
-                    expect(decimalPlaces(rawMakerAmt)).to.lte(2);
-                    expect(decimalPlaces(rawTakerAmt)).to.lte(4);
-                    expect(roundNormal(rawMakerAmt / rawTakerAmt, 4)).to.gte(roundNormal(price, 4));
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(3);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 2)).to.gte(
+                            roundNormal(price, 2),
+                        );
 
-                    price += delta;
+                        price += delta_price;
+                    }
+                    size += delta_size;
                 }
-                size += delta;
-            }
+            });
+
+            it("0.01", async () => {
+                const delta_price = 0.01;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 100; ) {
+                    let price = 0.01;
+                    for (; price <= 1; ) {
+                        price = roundNormal(price, 8);
+                        const { rawMakerAmt, rawTakerAmt } = getMarketBuyOrderRawAmounts(
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.01"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(4);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 4)).to.gte(
+                            roundNormal(price, 4),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.001", async () => {
+                const delta_price = 0.001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 10; ) {
+                    let price = 0.001;
+                    for (; price <= 1; ) {
+                        price = roundNormal(price, 8);
+                        const { rawMakerAmt, rawTakerAmt } = getMarketBuyOrderRawAmounts(
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(5);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 6)).to.gte(
+                            roundNormal(price, 6),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
+
+            it("0.0001", async () => {
+                const delta_price = 0.0001;
+                const delta_size = 0.01;
+                let size = 0.01;
+
+                for (; size <= 1; ) {
+                    let price = 0.0001;
+                    for (; price <= 1; ) {
+                        price = roundNormal(price, 8);
+                        const { rawMakerAmt, rawTakerAmt } = getMarketBuyOrderRawAmounts(
+                            size,
+                            price,
+                            ROUNDING_CONFIG["0.0001"],
+                        );
+
+                        expect(decimalPlaces(rawMakerAmt)).to.lte(2);
+                        expect(decimalPlaces(rawTakerAmt)).to.lte(6);
+                        expect(roundNormal(rawMakerAmt / rawTakerAmt, 8)).to.gte(
+                            roundNormal(price, 8),
+                        );
+
+                        price += delta_price;
+                    }
+                    size += delta_size;
+                }
+            });
         });
     });
 
     describe("buildMarketBuyOrderCreationArgs", () => {
-        it("market buy order", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.56,
-                amount: 100,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "0x0000000000000000000000000000000000000001",
-                "0x0000000000000000000000000000000000000002",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData).deep.equal({
-                maker: "0x0000000000000000000000000000000000000002",
-                taker: "0x0000000000000000000000000000000000000000",
-                tokenId: "123",
-                makerAmount: "100000000",
-                takerAmount: "178571400",
-                side: UtilsSide.BUY,
-                feeRateBps: "111",
-                nonce: "123",
-                signer: "0x0000000000000000000000000000000000000001",
-                expiration: "50000",
-                signatureType: SignatureType.EOA,
+        describe("market buy order", async () => {
+            it("0.1", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.5,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.1"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "100000000",
+                    takerAmount: "200000000",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.01", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.56,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.01"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "100000000",
+                    takerAmount: "178571400",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.001", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.056,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "100000000",
+                    takerAmount: "1785714280",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
+            });
+
+            it("0.0001", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.0056,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+                const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                    "0x0000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000002",
+                    SignatureType.EOA,
+                    order,
+                    ROUNDING_CONFIG["0.0001"],
+                );
+                expect(orderData).deep.equal({
+                    maker: "0x0000000000000000000000000000000000000002",
+                    taker: "0x0000000000000000000000000000000000000000",
+                    tokenId: "123",
+                    makerAmount: "100000000",
+                    takerAmount: "17857142857",
+                    side: UtilsSide.BUY,
+                    feeRateBps: "111",
+                    nonce: "123",
+                    signer: "0x0000000000000000000000000000000000000001",
+                    expiration: "50000",
+                    signatureType: SignatureType.EOA,
+                });
             });
         });
 
-        it("market buy order with a different price", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.5,
-                amount: 100,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "0x0000000000000000000000000000000000000001",
-                "0x0000000000000000000000000000000000000002",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData).deep.equal({
-                maker: "0x0000000000000000000000000000000000000002",
-                taker: "0x0000000000000000000000000000000000000000",
-                tokenId: "123",
-                makerAmount: "100000000",
-                takerAmount: "200000000",
-                side: UtilsSide.BUY,
-                feeRateBps: "111",
-                nonce: "123",
-                signer: "0x0000000000000000000000000000000000000001",
-                expiration: "50000",
-                signatureType: SignatureType.EOA,
+        describe("real cases", async () => {
+            describe("0.1", async () => {
+                it("market buy order with a different price", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        amount: 100,
+                        feeRateBps: 111,
+                        nonce: 123,
+                        expiration: 50000,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "0x0000000000000000000000000000000000000001",
+                        "0x0000000000000000000000000000000000000002",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData).deep.equal({
+                        maker: "0x0000000000000000000000000000000000000002",
+                        taker: "0x0000000000000000000000000000000000000000",
+                        tokenId: "123",
+                        makerAmount: "100000000",
+                        takerAmount: "200000000",
+                        side: UtilsSide.BUY,
+                        feeRateBps: "111",
+                        nonce: "123",
+                        signer: "0x0000000000000000000000000000000000000001",
+                        expiration: "50000",
+                        signatureType: SignatureType.EOA,
+                    });
+                });
+
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        amount: 21.04,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        2,
+                    );
+                    expect(price).to.equal(0.5);
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.5,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        amount: 119,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("170000000");
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        2,
+                    );
+                    expect(price).to.equal(0.7);
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.8,
+                        amount: 82.8,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("82800000");
+                    expect(orderData.takerAmount).to.equal("103500000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.8,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.7,
+                        amount: 9.9996,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9990000");
+                    expect(orderData.takerAmount).to.equal("14271000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.7,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.3,
+                        amount: 949.9971,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("949990000");
+                    expect(orderData.takerAmount).to.equal("3166633000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.3,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 6", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.1"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("2000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.5,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 7", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.5,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("2000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.5,
+                    );
+                });
             });
-        });
 
-        it("correctly rounds price amounts for validity buy", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.56,
-                amount: 21.04,
-                feeRateBps: 100,
-                nonce: 0,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
+            describe("0.01", async () => {
+                it("market buy order with a different price", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.05,
+                        amount: 100,
+                        feeRateBps: 111,
+                        nonce: 123,
+                        expiration: 50000,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "0x0000000000000000000000000000000000000001",
+                        "0x0000000000000000000000000000000000000002",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData).deep.equal({
+                        maker: "0x0000000000000000000000000000000000000002",
+                        taker: "0x0000000000000000000000000000000000000000",
+                        tokenId: "123",
+                        makerAmount: "100000000",
+                        takerAmount: "2000000000",
+                        side: UtilsSide.BUY,
+                        feeRateBps: "111",
+                        nonce: "123",
+                        signer: "0x0000000000000000000000000000000000000001",
+                        expiration: "50000",
+                        signatureType: SignatureType.EOA,
+                    });
+                });
 
-            const price = roundDown(
-                Number(orderData.makerAmount) / Number(orderData.takerAmount),
-                2,
-            );
-            expect(price).to.equal(0.56);
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.greaterThan(
-                0.56,
-            );
-        });
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.56,
+                        amount: 21.04,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
 
-        it("correctly rounds price amounts for validity buy - 2", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.7,
-                amount: 119,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        2,
+                    );
+                    expect(price).to.equal(0.56);
+                    expect(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                    ).to.greaterThan(0.56);
+                });
 
-            expect(orderData.makerAmount).to.equal("119000000");
-            expect(orderData.takerAmount).to.equal("170000000");
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.07,
+                        amount: 119,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
 
-            const price = roundDown(
-                Number(orderData.makerAmount) / Number(orderData.takerAmount),
-                2,
-            );
-            expect(price).to.equal(0.7);
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.7);
-        });
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("1700000000");
 
-        it("correctly rounds price amounts for validity buy - 3", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.82,
-                amount: 82.82,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("82820000");
-            expect(orderData.takerAmount).to.equal("101000000");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.82);
-        });
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        2,
+                    );
+                    expect(price).to.equal(0.07);
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.07,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 4", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.78,
-                amount: 9.9996,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("9990000");
-            expect(orderData.takerAmount).to.equal("12807600");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.78);
-        });
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.82,
+                        amount: 82.82,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("82820000");
+                    expect(orderData.takerAmount).to.equal("101000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.82,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 5", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.39,
-                amount: 949.9971,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("949990000");
-            expect(orderData.takerAmount).to.equal("2435871700");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.39);
-        });
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.78,
+                        amount: 9.9996,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9990000");
+                    expect(orderData.takerAmount).to.equal("12807600");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.78,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 6", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.56,
-                amount: 1,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("1000000");
-            expect(orderData.takerAmount).to.equal("1785700");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.39);
-        });
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.39,
+                        amount: 949.9971,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("949990000");
+                    expect(orderData.takerAmount).to.equal("2435871700");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.39,
+                    );
+                });
 
-        it("correctly rounds price amounts for validity buy - 7", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.57,
-                amount: 1,
-            };
-            const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
-                "",
-                "",
-                SignatureType.EOA,
-                order,
-            );
-            expect(orderData.makerAmount).to.equal("1000000");
-            expect(orderData.takerAmount).to.equal("1754300");
-            expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(0.39);
+                it("correctly rounds price amounts for validity buy - 6", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.56,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("1785700");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.56,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 7", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.57,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.01"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("1754300");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.57,
+                    );
+                });
+            });
+
+            describe("0.001", async () => {
+                it("market buy order with a different price", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.005,
+                        amount: 100,
+                        feeRateBps: 111,
+                        nonce: 123,
+                        expiration: 50000,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "0x0000000000000000000000000000000000000001",
+                        "0x0000000000000000000000000000000000000002",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData).deep.equal({
+                        maker: "0x0000000000000000000000000000000000000002",
+                        taker: "0x0000000000000000000000000000000000000000",
+                        tokenId: "123",
+                        makerAmount: "100000000",
+                        takerAmount: "20000000000",
+                        side: UtilsSide.BUY,
+                        feeRateBps: "111",
+                        nonce: "123",
+                        signer: "0x0000000000000000000000000000000000000001",
+                        expiration: "50000",
+                        signatureType: SignatureType.EOA,
+                    });
+                });
+
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.056,
+                        amount: 21.04,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        6,
+                    );
+                    expect(price).to.equal(0.056);
+                    expect(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                    ).to.greaterThan(0.056);
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.007,
+                        amount: 119,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("17000000000");
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        6,
+                    );
+                    expect(price).to.equal(0.007);
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.082,
+                        amount: 82.82,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("82820000");
+                    expect(orderData.takerAmount).to.equal("1010000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.078,
+                        amount: 9.9996,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9990000");
+                    expect(orderData.takerAmount).to.equal("128076920");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.039,
+                        amount: 949.9971,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("949990000");
+                    expect(orderData.takerAmount).to.equal("24358717940");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.039,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 6", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.056,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("17857140");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 7", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.057,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("17543850");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.057,
+                    );
+                });
+            });
+
+            describe("0.0001", async () => {
+                it("market buy order with a different price", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0005,
+                        amount: 100,
+                        feeRateBps: 111,
+                        nonce: 123,
+                        expiration: 50000,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "0x0000000000000000000000000000000000000001",
+                        "0x0000000000000000000000000000000000000002",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData).deep.equal({
+                        maker: "0x0000000000000000000000000000000000000002",
+                        taker: "0x0000000000000000000000000000000000000000",
+                        tokenId: "123",
+                        makerAmount: "100000000",
+                        takerAmount: "200000000000",
+                        side: UtilsSide.BUY,
+                        feeRateBps: "111",
+                        nonce: "123",
+                        signer: "0x0000000000000000000000000000000000000001",
+                        expiration: "50000",
+                        signatureType: SignatureType.EOA,
+                    });
+                });
+
+                it("correctly rounds price amounts for validity buy", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0056,
+                        amount: 21.04,
+                        feeRateBps: 100,
+                        nonce: 0,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        8,
+                    );
+                    expect(price).to.equal(0.0056);
+                    expect(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                    ).to.greaterThan(0.0056);
+                });
+
+                it("correctly rounds price amounts for validity buy - 2", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0007,
+                        amount: 119,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+
+                    expect(orderData.makerAmount).to.equal("119000000");
+                    expect(orderData.takerAmount).to.equal("170000000000");
+
+                    const price = roundDown(
+                        Number(orderData.makerAmount) / Number(orderData.takerAmount),
+                        8,
+                    );
+                    expect(price).to.equal(0.0007);
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0007,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 3", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0082,
+                        amount: 82.82,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("82820000");
+                    expect(orderData.takerAmount).to.equal("10100000000");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0082,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 4", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0078,
+                        amount: 9.9996,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("9990000");
+                    expect(orderData.takerAmount).to.equal("1280769230");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0078,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 5", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0039,
+                        amount: 949.9971,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("949990000");
+                    expect(orderData.takerAmount).to.equal("243587179487");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0039,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 6", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0056,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("178571428");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0056,
+                    );
+                });
+
+                it("correctly rounds price amounts for validity buy - 7", async () => {
+                    const order: UserMarketOrder = {
+                        tokenID: "123",
+                        price: 0.0057,
+                        amount: 1,
+                    };
+                    const orderData: OrderData = await buildMarketBuyOrderCreationArgs(
+                        "",
+                        "",
+                        SignatureType.EOA,
+                        order,
+                        ROUNDING_CONFIG["0.0001"],
+                    );
+                    expect(orderData.makerAmount).to.equal("1000000");
+                    expect(orderData.takerAmount).to.equal("175438596");
+                    expect(Number(orderData.makerAmount) / Number(orderData.takerAmount)).to.gte(
+                        0.0057,
+                    );
+                });
+            });
         });
     });
 
     describe("createMarketBuyOrder", () => {
-        it("buy order", async () => {
-            const order: UserMarketOrder = {
-                tokenID: "123",
-                price: 0.56,
-                amount: 100,
-                feeRateBps: 111,
-                nonce: 123,
-                expiration: 50000,
-            };
+        describe("buy order", async () => {
+            it("0.1", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.5,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
 
-            const signedOrder = await createMarketBuyOrder(
-                wallet,
-                Chain.MUMBAI,
-                SignatureType.EOA,
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                order,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                const signedOrder = await createMarketBuyOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.1",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
 
-            expect(signedOrder.salt).not.empty;
-            expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-            expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
-            expect(signedOrder.tokenId).equal("123");
-            expect(signedOrder.makerAmount).equal("100000000");
-            expect(signedOrder.takerAmount).equal("178571400");
-            expect(signedOrder.side).equal(UtilsSide.BUY);
-            expect(signedOrder.expiration).equal("50000");
-            expect(signedOrder.nonce).equal("123");
-            expect(signedOrder.feeRateBps).equal("111");
-            expect(signedOrder.signatureType).equal(SignatureType.EOA);
-            expect(signedOrder.signature).not.empty;
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("100000000");
+                expect(signedOrder.takerAmount).equal("200000000");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.01", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.56,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createMarketBuyOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.01",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("100000000");
+                expect(signedOrder.takerAmount).equal("178571400");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.001", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.056,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createMarketBuyOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.001",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("100000000");
+                expect(signedOrder.takerAmount).equal("1785714280");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
+
+            it("0.0001", async () => {
+                const order: UserMarketOrder = {
+                    tokenID: "123",
+                    price: 0.0056,
+                    amount: 100,
+                    feeRateBps: 111,
+                    nonce: 123,
+                    expiration: 50000,
+                };
+
+                const signedOrder = await createMarketBuyOrder(
+                    wallet,
+                    Chain.MUMBAI,
+                    SignatureType.EOA,
+                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                    order,
+                    "0.0001",
+                );
+                expect(signedOrder).not.null;
+                expect(signedOrder).not.undefined;
+
+                expect(signedOrder.salt).not.empty;
+                expect(signedOrder.maker).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.signer).equal("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+                expect(signedOrder.taker).equal("0x0000000000000000000000000000000000000000");
+                expect(signedOrder.tokenId).equal("123");
+                expect(signedOrder.makerAmount).equal("100000000");
+                expect(signedOrder.takerAmount).equal("17857142857");
+                expect(signedOrder.side).equal(UtilsSide.BUY);
+                expect(signedOrder.expiration).equal("50000");
+                expect(signedOrder.nonce).equal("123");
+                expect(signedOrder.feeRateBps).equal("111");
+                expect(signedOrder.signatureType).equal(SignatureType.EOA);
+                expect(signedOrder.signature).not.empty;
+            });
         });
     });
 });

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import {
     decimalPlaces,
     generateOrderBookSummaryHash,
+    isTickSizeSmaller,
     orderToJson,
     roundDown,
 } from "../src/utilities";
@@ -2944,5 +2945,31 @@ describe("utilities", () => {
             "7f81a35a09e1933a96b05edb51ac4be4a6163146",
         );
         expect(orderbook.hash).to.equal("7f81a35a09e1933a96b05edb51ac4be4a6163146");
+    });
+
+    it("isTickSizeSmaller", () => {
+        // 0.1
+        expect(isTickSizeSmaller("0.1", "0.1")).to.be.false;
+        expect(isTickSizeSmaller("0.1", "0.01")).to.be.false;
+        expect(isTickSizeSmaller("0.1", "0.001")).to.be.false;
+        expect(isTickSizeSmaller("0.1", "0.0001")).to.be.false;
+
+        // 0.01
+        expect(isTickSizeSmaller("0.01", "0.1")).to.be.true;
+        expect(isTickSizeSmaller("0.01", "0.01")).to.be.false;
+        expect(isTickSizeSmaller("0.01", "0.001")).to.be.false;
+        expect(isTickSizeSmaller("0.01", "0.0001")).to.be.false;
+
+        // 0.001
+        expect(isTickSizeSmaller("0.001", "0.1")).to.be.true;
+        expect(isTickSizeSmaller("0.001", "0.01")).to.be.true;
+        expect(isTickSizeSmaller("0.001", "0.001")).to.be.false;
+        expect(isTickSizeSmaller("0.001", "0.0001")).to.be.false;
+
+        // 0.0001
+        expect(isTickSizeSmaller("0.0001", "0.1")).to.be.true;
+        expect(isTickSizeSmaller("0.0001", "0.01")).to.be.true;
+        expect(isTickSizeSmaller("0.0001", "0.001")).to.be.true;
+        expect(isTickSizeSmaller("0.0001", "0.0001")).to.be.false;
     });
 });

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -233,614 +233,2645 @@ describe("utilities", () => {
             });
         });
 
-        it("All orders combinations", async () => {
-            // publicly known private key
-            const token =
-                "1343197538147866997676250008839231694243646439454152539053893078719042421992";
-            const privateKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-            const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-            const wallet = new Wallet(privateKey);
-            const chainId = Chain.MUMBAI;
-            const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
+        describe("All orders combinations", async () => {
+            describe("0.1", async () => {
+                // publicly known private key
+                const token =
+                    "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+                const privateKey =
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+                const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+                const wallet = new Wallet(privateKey);
+                const chainId = Chain.MUMBAI;
+                const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
 
-            // GTD BUY EOA
-            let userOrder: UserOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-                expiration: 1709948026,
-            };
-            let signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.EOA,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                it("GTD BUY EOA", async () => {
+                    const userOrder: UserOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            let jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 0,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTC BUY EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("FOK BUY EOA", async () => {
+                    const userMarketOrder: UserMarketOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userMarketOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_PROXY", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userMarketOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_GNOSIS_SAFE", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.5,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userMarketOrder,
+                        "0.1",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
             });
 
-            // GTD BUY POLY_PROXY
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-                expiration: 1709948026,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_PROXY,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+            describe("0.01", async () => {
+                // publicly known private key
+                const token =
+                    "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+                const privateKey =
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+                const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+                const wallet = new Wallet(privateKey);
+                const chainId = Chain.MUMBAI;
+                const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
 
-            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                it("GTD BUY EOA", async () => {
+                    const userOrder: UserOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 1,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTC BUY EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "5000000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "5000000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("FOK BUY EOA", async () => {
+                    const userMarketOrder: UserMarketOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userMarketOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "2000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_PROXY", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userMarketOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "2000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_GNOSIS_SAFE", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.05,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userMarketOrder,
+                        "0.01",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "2000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
             });
 
-            // GTD BUY POLY_GNOSIS_SAFE
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-                expiration: 1709948026,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_GNOSIS_SAFE,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+            describe("0.001", async () => {
+                // publicly known private key
+                const token =
+                    "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+                const privateKey =
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+                const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+                const wallet = new Wallet(privateKey);
+                const chainId = Chain.MUMBAI;
+                const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
 
-            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                it("GTD BUY EOA", async () => {
+                    const userOrder: UserOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 2,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTD SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
+
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
+
+                it("GTC BUY EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "500000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("GTC SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "500000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("FOK BUY EOA", async () => {
+                    const userMarketOrder: UserMarketOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userMarketOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "20000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_PROXY", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userMarketOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "20000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_GNOSIS_SAFE", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userMarketOrder,
+                        "0.001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "20000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
             });
 
-            // GTD SELL EOA
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-                expiration: 1709948026,
-            };
-            signedOrder = await createOrder(wallet, chainId, SignatureType.EOA, address, userOrder);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+            describe("0.0001", async () => {
+                // publicly known private key
+                const token =
+                    "1343197538147866997676250008839231694243646439454152539053893078719042421992";
+                const privateKey =
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+                const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+                const wallet = new Wallet(privateKey);
+                const chainId = Chain.MUMBAI;
+                const owner = "f4f247b7-4ac7-ff29-a152-04fda0a8755a";
 
-            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                it("GTD BUY EOA", async () => {
+                    const userOrder: UserOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 0,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTD SELL POLY_PROXY
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-                expiration: 1709948026,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_PROXY,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                it("GTD BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 1,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTD SELL POLY_GNOSIS_SAFE
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-                expiration: 1709948026,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_GNOSIS_SAFE,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
-            expect(jsonGTDOrder).not.null;
-            expect(jsonGTDOrder).not.undefined;
+                it("GTD BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTDOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "1709948026",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 2,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTD,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTC BUY EOA
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-            };
-            signedOrder = await createOrder(wallet, chainId, SignatureType.EOA, address, userOrder);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            let jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTD SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 0,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTC BUY POLY_PROXY
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_PROXY,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTD SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 1,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTC BUY POLY_GNOSIS_SAFE
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.BUY,
-                size: 100,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_GNOSIS_SAFE,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTD SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                        expiration: 1709948026,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "50000000",
-                    takerAmount: "100000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 2,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTDOrder = orderToJson(signedOrder, owner, OrderType.GTD);
+                    expect(jsonGTDOrder).not.null;
+                    expect(jsonGTDOrder).not.undefined;
 
-            // GTC SELL EOA
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-            };
-            signedOrder = await createOrder(wallet, chainId, SignatureType.EOA, address, userOrder);
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTDOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "1709948026",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTD,
+                    });
+                });
 
-            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTC BUY EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 0,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
 
-            // GTC SELL POLY_PROXY
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_PROXY,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
 
-            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTC BUY POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 1,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
 
-            // GTC SELL POLY_GNOSIS_SAFE
-            userOrder = {
-                tokenID: token,
-                price: 0.5,
-                side: Side.SELL,
-                size: 100,
-            };
-            signedOrder = await createOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_GNOSIS_SAFE,
-                address,
-                userOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
 
-            jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
-            expect(jsonGTCOrder).not.null;
-            expect(jsonGTCOrder).not.undefined;
+                it("GTC BUY POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.BUY,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonGTCOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "50000000",
-                    side: "SELL",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 2,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.GTC,
-            });
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
 
-            // FOK BUY EOA
-            let userMarketOrder: UserMarketOrder = {
-                tokenID: token,
-                price: 0.5,
-                amount: 100,
-            };
-            signedOrder = await createMarketBuyOrder(
-                wallet,
-                chainId,
-                SignatureType.EOA,
-                address,
-                userMarketOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "50000",
+                            takerAmount: "100000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
 
-            let jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonFOKOrder).not.null;
-            expect(jsonFOKOrder).not.undefined;
+                it("GTC SELL EOA", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonFOKOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "200000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 0,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.FOK,
-            });
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
 
-            // FOK BUY POLY_PROXY
-            userMarketOrder = {
-                tokenID: token,
-                price: 0.5,
-                amount: 100,
-            };
-            signedOrder = await createMarketBuyOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_PROXY,
-                address,
-                userMarketOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
 
-            jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonFOKOrder).not.null;
-            expect(jsonFOKOrder).not.undefined;
+                it("GTC SELL POLY_PROXY", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonFOKOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "200000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 1,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.FOK,
-            });
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
 
-            // FOK BUY POLY_GNOSIS_SAFE
-            userMarketOrder = {
-                tokenID: token,
-                price: 0.5,
-                amount: 100,
-            };
-            signedOrder = await createMarketBuyOrder(
-                wallet,
-                chainId,
-                SignatureType.POLY_GNOSIS_SAFE,
-                address,
-                userMarketOrder,
-            );
-            expect(signedOrder).not.null;
-            expect(signedOrder).not.undefined;
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
 
-            jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
-            expect(jsonFOKOrder).not.null;
-            expect(jsonFOKOrder).not.undefined;
+                it("GTC SELL POLY_GNOSIS_SAFE", async () => {
+                    const userOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        side: Side.SELL,
+                        size: 100,
+                    };
+                    const signedOrder = await createOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
 
-            expect(jsonFOKOrder).deep.equal({
-                order: {
-                    salt: parseInt(signedOrder.salt),
-                    maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                    taker: "0x0000000000000000000000000000000000000000",
-                    tokenId: token,
-                    makerAmount: "100000000",
-                    takerAmount: "200000000",
-                    side: "BUY",
-                    expiration: "0",
-                    nonce: "0",
-                    feeRateBps: "0",
-                    signatureType: 2,
-                    signature: signedOrder.signature,
-                },
-                owner: owner,
-                orderType: OrderType.FOK,
+                    const jsonGTCOrder = orderToJson(signedOrder, owner, OrderType.GTC);
+                    expect(jsonGTCOrder).not.null;
+                    expect(jsonGTCOrder).not.undefined;
+
+                    expect(jsonGTCOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "50000",
+                            side: "SELL",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.GTC,
+                    });
+                });
+
+                it("FOK BUY EOA", async () => {
+                    const userMarketOrder: UserMarketOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.EOA,
+                        address,
+                        userMarketOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 0,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_PROXY", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_PROXY,
+                        address,
+                        userMarketOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 1,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
+
+                it("FOK BUY POLY_GNOSIS_SAFE", async () => {
+                    const userMarketOrder = {
+                        tokenID: token,
+                        price: 0.0005,
+                        amount: 100,
+                    };
+                    const signedOrder = await createMarketBuyOrder(
+                        wallet,
+                        chainId,
+                        SignatureType.POLY_GNOSIS_SAFE,
+                        address,
+                        userMarketOrder,
+                        "0.0001",
+                    );
+                    expect(signedOrder).not.null;
+                    expect(signedOrder).not.undefined;
+
+                    const jsonFOKOrder = orderToJson(signedOrder, owner, OrderType.FOK);
+                    expect(jsonFOKOrder).not.null;
+                    expect(jsonFOKOrder).not.undefined;
+
+                    expect(jsonFOKOrder).deep.equal({
+                        order: {
+                            salt: parseInt(signedOrder.salt),
+                            maker: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            signer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                            taker: "0x0000000000000000000000000000000000000000",
+                            tokenId: token,
+                            makerAmount: "100000000",
+                            takerAmount: "200000000000",
+                            side: "BUY",
+                            expiration: "0",
+                            nonce: "0",
+                            feeRateBps: "0",
+                            signatureType: 2,
+                            signature: signedOrder.signature,
+                        },
+                        owner: owner,
+                        orderType: OrderType.FOK,
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
Adding support for:
- `0.1`
- `0.01` - already supported
- `0.001`
- `0.0001`


### Example
```ts
const YES = "1343197538147866997676250008839231694243646439454152539053893078719042421992";
const order = await clobClient.createOrder({
    tokenID: YES,
    price: 0.0005, // <---- price
    side: Side.BUY,
    size: 41,
    feeRateBps: 0,
    nonce: 0,
    expiration: 0,
});
console.log("Created Order", order);

// Send it to the server
const resp = await clobClient.postOrder(order);
console.log(resp);
```