### PR TITLE
Fix: Builder flow upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "4.22.1",
+    "version": "4.22.2",
     "contributors": [
         {
             "name": "Jonathan Amenechi",
@@ -45,7 +45,7 @@
         "test": "make test"
     },
     "dependencies": {
-        "@polymarket/builder-signing-sdk": "^0.0.3",
+        "@polymarket/builder-signing-sdk": "^0.0.5",
         "@polymarket/order-utils": "^2.1.0",
         "axios": "^0.27.2",
         "browser-or-node": "^2.1.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { Wallet } from "@ethersproject/wallet";
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { SignatureType, SignedOrder } from "@polymarket/order-utils";
-import { BuilderConfig, BuilderType } from "@polymarket/builder-signing-sdk";
+import { BuilderConfig } from "@polymarket/builder-signing-sdk";
 import {
     ApiKeyCreds,
     ApiKeysResponse,
@@ -1178,22 +1178,7 @@ export class ClobClient {
         headerArgs: L2HeaderArgs,
     ): Promise<L2WithBuilderHeader | undefined> {
 
-        // If local builder creds are available, use these
-        if (this.builderConfig !== undefined && this.builderConfig.getBuilderType() == BuilderType.LOCAL) {
-            const builderHeaders = await this.builderConfig.generateBuilderHeaders(
-                headerArgs.method,
-                headerArgs.requestPath,
-                headerArgs.body,
-            )
-            if (builderHeaders == undefined) {
-                return undefined;
-            }
-            return injectBuilderHeaders(headers, builderHeaders);
-            
-        }
-
-        // If the remote builder signer is available, use it
-        if (this.builderConfig !== undefined && this.builderConfig.getBuilderType() == BuilderType.REMOTE) {
+        if (this.builderConfig !== undefined) {
             const builderHeaders = await this.builderConfig.generateBuilderHeaders(
                 headerArgs.method,
                 headerArgs.requestPath,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { Wallet } from "@ethersproject/wallet";
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { SignatureType, SignedOrder } from "@polymarket/order-utils";
-import { BuilderConfig, BuilderHeaderPayload } from "@polymarket/builder-signing-sdk";
+import { BuilderConfig, BuilderType } from "@polymarket/builder-signing-sdk";
 import {
     ApiKeyCreds,
     ApiKeysResponse,
@@ -49,7 +49,7 @@ import {
     L2PolyHeader,
     L2HeaderArgs,
 } from "./types";
-import { createBuilderHeaders, createL1Headers, createL2Headers, injectBuilderHeaders } from "./headers";
+import { createL1Headers, createL2Headers, injectBuilderHeaders } from "./headers";
 import {
     del,
     DELETE,
@@ -1146,16 +1146,7 @@ export class ClobClient {
     }
 
     private canBuilderAuth(): boolean {
-        // Can builder auth if builder config is set up with local builder credentials or a remote builder signer
-        return this.builderConfig !== undefined && 
-        (
-            (this.builderConfig.localBuilderCreds !== undefined)
-            ||
-            (
-                this.builderConfig.remoteBuilderSignerUrl !== undefined &&
-                this.builderConfig.remoteBuilderSignerUrl.length > 0
-            )
-        )
+        return (this.builderConfig != undefined && this.builderConfig.isValid())
     }
 
     private async _resolveTickSize(tokenID: string, tickSize?: TickSize): Promise<TickSize> {
@@ -1188,24 +1179,29 @@ export class ClobClient {
     ): Promise<L2WithBuilderHeader | undefined> {
 
         // If local builder creds are available, use these
-        if (this.builderConfig !== undefined && this.builderConfig.localBuilderCreds !== undefined) {
-            return createBuilderHeaders(this.builderConfig.localBuilderCreds, headers, headerArgs);
+        if (this.builderConfig !== undefined && this.builderConfig.getBuilderType() == BuilderType.LOCAL) {
+            const builderHeaders = await this.builderConfig.generateBuilderHeaders(
+                headerArgs.method,
+                headerArgs.requestPath,
+                headerArgs.body,
+            )
+            if (builderHeaders == undefined) {
+                return undefined;
+            }
+            return injectBuilderHeaders(headers, builderHeaders);
+            
         }
 
         // If the remote builder signer is available, use it
-        if (this.builderConfig !== undefined && this.builderConfig.remoteBuilderSignerUrl !== undefined) {
-            const remoteSignerUrl = this.builderConfig.remoteBuilderSignerUrl;
-            // Execute a POST to the remote signer url with the header arguments
-            const builderHeaders: BuilderHeaderPayload = await post(
-                remoteSignerUrl,
-                { 
-                    data: {
-                        method: headerArgs.method,
-                        path: headerArgs.requestPath,
-                        body: headerArgs.body,
-                    }
-                }
+        if (this.builderConfig !== undefined && this.builderConfig.getBuilderType() == BuilderType.REMOTE) {
+            const builderHeaders = await this.builderConfig.generateBuilderHeaders(
+                headerArgs.method,
+                headerArgs.requestPath,
+                headerArgs.body,
             );
+            if (builderHeaders == undefined) {
+                return undefined;
+            }
             return injectBuilderHeaders(headers, builderHeaders);
         }
 

--- a/src/headers/index.ts
+++ b/src/headers/index.ts
@@ -65,17 +65,9 @@ export const createL2Headers = async (
 export const injectBuilderHeaders = (
     l2Header: L2PolyHeader,
     builderHeaders: BuilderHeaderPayload,
-): L2WithBuilderHeader => {
-    return {
-        POLY_ADDRESS: l2Header.POLY_ADDRESS,
-        POLY_SIGNATURE: l2Header.POLY_SIGNATURE,
-        POLY_TIMESTAMP: l2Header.POLY_TIMESTAMP,
-        POLY_API_KEY: l2Header.POLY_API_KEY,
-        POLY_PASSPHRASE: l2Header.POLY_PASSPHRASE,
-        POLY_BUILDER_API_KEY: builderHeaders.POLY_BUILDER_API_KEY,
-        POLY_BUILDER_PASSPHRASE: builderHeaders.POLY_BUILDER_PASSPHRASE,
-        POLY_BUILDER_TIMESTAMP: builderHeaders.POLY_BUILDER_TIMESTAMP,
-        POLY_BUILDER_SIGNATURE: builderHeaders.POLY_BUILDER_SIGNATURE,
-    };
-}
+): L2WithBuilderHeader => ({
+    ...l2Header,
+    ...builderHeaders,
+}) as L2WithBuilderHeader;
+  
 

--- a/src/headers/index.ts
+++ b/src/headers/index.ts
@@ -2,7 +2,7 @@ import { JsonRpcSigner } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
 import { buildClobEip712Signature, buildPolyHmacSignature } from "../signing";
 import { ApiKeyCreds, Chain, L1PolyHeader, L2HeaderArgs, L2PolyHeader, L2WithBuilderHeader } from "../types";
-import { BuilderApiKeyCreds, BuilderHeaderPayload, BuilderSigner } from "@polymarket/builder-signing-sdk";
+import { BuilderHeaderPayload } from "@polymarket/builder-signing-sdk";
 
 export const createL1Headers = async (
     signer: Wallet | JsonRpcSigner,
@@ -60,21 +60,6 @@ export const createL2Headers = async (
     };
 
     return headers;
-};
-
-export const createBuilderHeaders = async (
-    builderCreds: BuilderApiKeyCreds,
-    l2Header: L2PolyHeader,
-    l2HeaderArgs: L2HeaderArgs,
-): Promise<L2WithBuilderHeader> => {
-    const signer = new BuilderSigner(builderCreds);
-    const builderHeaders = signer.createBuilderHeaderPayload(
-        l2HeaderArgs.method,
-        l2HeaderArgs.requestPath,
-        l2HeaderArgs.body,
-    );
-
-    return injectBuilderHeaders(l2Header, builderHeaders);
 };
 
 export const injectBuilderHeaders = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,12 +687,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@polymarket/builder-signing-sdk@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.3.tgz#ac0578dad1a5c149390abeccf5147189e16b41e0"
-  integrity sha512-yRO/tV2+33dC44nq+TCkgp+LFF2KmVzg+wN+S6zAGIJ2BFvlBXfgnzeu2LZi4aoORBJENAvv/x2kj4kXVaH8sg==
+"@polymarket/builder-signing-sdk@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.5.tgz#5f52cb932a04355ee3e21e80bc79b77d8fe63dd3"
+  integrity sha512-Y7YG2L9GiF6PBHYyV+qFT46MQB46XQHqmVE7+nf+eH2nLwqhqvFs9yUpyjwDtlF68o5SQdEIpPO8m8ZM9reB6g==
   dependencies:
     "@types/node" "^18.7.18"
+    axios "^1.12.2"
+    tslib "^2.8.1"
 
 "@polymarket/order-utils@^2.1.0":
   version "2.1.0"
@@ -1110,6 +1112,15 @@ axios@^0.27.2:
   dependencies:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
+
+axios@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2114,7 +2125,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.14.9, follow-redirects@^1.15.6:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -2134,7 +2145,7 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
@@ -3343,6 +3354,11 @@ process@^0.11.1:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
@@ -3861,6 +3877,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
* Use upgraded builder-signer-sdk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades builder-signing-sdk and refactors builder auth to delegate header generation to BuilderConfig, removing inline/remote signer logic and simplifying header injection.
> 
> - **Builder Auth Flow**:
>   - Use `BuilderConfig.isValid()` and `BuilderConfig.generateBuilderHeaders(...)` to determine/authenticate builder requests.
>   - Remove local/remote builder header generation logic and related `POST` to remote signer.
>   - Simplify `injectBuilderHeaders` by merging `L2` and builder headers.
> - **Headers Module**:
>   - Remove `createBuilderHeaders` and all `BuilderSigner` usage.
>   - Keep only `BuilderHeaderPayload` import; streamline `injectBuilderHeaders` implementation.
> - **Dependencies**:
>   - Bump `@polymarket/builder-signing-sdk` to `^0.0.5`.
>   - Version bump to `4.22.2` and lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d3942ca9cdc2db9c56fb08088d69680c1183897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->