### PR TITLE
Fix: get builder trades

### DIFF
--- a/examples/getBuilderTrades.ts
+++ b/examples/getBuilderTrades.ts
@@ -1,0 +1,40 @@
+import { ethers } from "ethers";
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+import { ApiKeyCreds, Chain, ClobClient } from "../src";
+import { BuilderApiKeyCreds, BuilderConfig } from "@polymarket/builder-signing-sdk";
+
+dotenvConfig({ path: resolve(__dirname, "../.env") });
+
+
+async function main() {
+    const wallet = new ethers.Wallet(`${process.env.PK}`);
+    const chainId = parseInt(`${process.env.CHAIN_ID_PROD || Chain.AMOY}`) as Chain;
+    console.log(`Address: ${await wallet.getAddress()}, chainId: ${chainId}`);
+
+    const host = process.env.CLOB_API_URL_PROD || "http://localhost:8080";
+    const creds: ApiKeyCreds = {
+        key: `${process.env.CLOB_API_KEY_PROD}`,
+        secret: `${process.env.CLOB_SECRET_PROD}`,
+        passphrase: `${process.env.CLOB_PASS_PHRASE_PROD}`,
+    };
+
+    const builderCreds: BuilderApiKeyCreds = {
+        key: `${process.env.BUILDER_API_KEY}`,
+        secret: `${process.env.BUILDER_SECRET}`,
+        passphrase: `${process.env.BUILDER_PASS_PHRASE}`,
+    };
+    const builderConfig = new BuilderConfig({
+        localBuilderCreds: builderCreds
+    });
+    // const builderConfig = new BuilderConfig({
+    //     remoteBuilderSignerUrl: "http://localhost:8080/sign"
+    // });
+    const clobClient = new ClobClient(host, chainId, wallet, creds, undefined, undefined, undefined, false, builderConfig);
+
+    const trades = await clobClient.getBuilderTrades();
+    console.log(trades);
+    console.log(`Done!`);
+}
+
+main();

--- a/examples/getBuilderTrades.ts
+++ b/examples/getBuilderTrades.ts
@@ -9,14 +9,14 @@ dotenvConfig({ path: resolve(__dirname, "../.env") });
 
 async function main() {
     const wallet = new ethers.Wallet(`${process.env.PK}`);
-    const chainId = parseInt(`${process.env.CHAIN_ID_PROD || Chain.AMOY}`) as Chain;
+    const chainId = parseInt(`${process.env.CHAIN_ID || Chain.AMOY}`) as Chain;
     console.log(`Address: ${await wallet.getAddress()}, chainId: ${chainId}`);
 
-    const host = process.env.CLOB_API_URL_PROD || "http://localhost:8080";
+    const host = process.env.CLOB_API_URL || "http://localhost:8080";
     const creds: ApiKeyCreds = {
-        key: `${process.env.CLOB_API_KEY_PROD}`,
-        secret: `${process.env.CLOB_SECRET_PROD}`,
-        passphrase: `${process.env.CLOB_PASS_PHRASE_PROD}`,
+        key: `${process.env.CLOB_API_KEY}`,
+        secret: `${process.env.CLOB_SECRET}`,
+        passphrase: `${process.env.CLOB_PASS_PHRASE}`,
     };
 
     const builderCreds: BuilderApiKeyCreds = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "4.22.2",
+    "version": "4.22.3",
     "contributors": [
         {
             "name": "Jonathan Amenechi",
@@ -45,7 +45,7 @@
         "test": "make test"
     },
     "dependencies": {
-        "@polymarket/builder-signing-sdk": "^0.0.5",
+        "@polymarket/builder-signing-sdk": "^0.0.6",
         "@polymarket/order-utils": "^2.1.0",
         "axios": "^0.27.2",
         "browser-or-node": "^2.1.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,7 +61,7 @@ import {
     post,
     RequestOptions,
 } from "./http-helpers";
-import { BUILDER_AUTH_NOT_AVAILABLE, L1_AUTH_UNAVAILABLE_ERROR, L2_AUTH_NOT_AVAILABLE } from "./errors";
+import { BUILDER_AUTH_FAILED, BUILDER_AUTH_NOT_AVAILABLE, L1_AUTH_UNAVAILABLE_ERROR, L2_AUTH_NOT_AVAILABLE } from "./errors";
 import {
     generateOrderBookSummaryHash,
     isTickSizeSmaller,
@@ -552,7 +552,6 @@ export class ClobClient {
         return { trades: Array.isArray(data) ? [...data] : [], ...rest };
     }
 
-
     public async getBuilderTrades(
         params?: TradeParams,
         next_cursor?: string,
@@ -571,6 +570,9 @@ export class ClobClient {
             headerArgs.method,
             headerArgs.requestPath,
         );
+        if (headers == undefined) {
+            throw BUILDER_AUTH_FAILED; 
+        }
 
         next_cursor = next_cursor || INITIAL_CURSOR;
 
@@ -1239,7 +1241,7 @@ export class ClobClient {
         method: string,
         path: string,
         body?: string
-    ): Promise<BuilderHeaderPayload| undefined> {
+    ): Promise<BuilderHeaderPayload | undefined> {
         return (this.builderConfig as BuilderConfig).generateBuilderHeaders(
             method,
             path,

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -62,3 +62,6 @@ export const GET_LIQUIDITY_REWARD_PERCENTAGES = "/rewards/user/percentages";
 export const GET_REWARDS_MARKETS_CURRENT = "/rewards/markets/current";
 export const GET_REWARDS_MARKETS = "/rewards/markets/";
 export const GET_REWARDS_EARNINGS_PERCENTAGES = "/rewards/user/markets";
+
+// Builder endpoints
+export const GET_BUILDER_TRADES = "/builder/trades";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,3 +9,7 @@ export const L2_AUTH_NOT_AVAILABLE = new Error(
 export const BUILDER_AUTH_NOT_AVAILABLE = new Error(
     "Builder API Credentials needed to interact with this endpoint!",
 );
+
+export const BUILDER_AUTH_FAILED = new Error(
+    "Builder auth failed!",
+);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,3 +5,7 @@ export const L1_AUTH_UNAVAILABLE_ERROR = new Error(
 export const L2_AUTH_NOT_AVAILABLE = new Error(
     "API Credentials are needed to interact with this endpoint!",
 );
+
+export const BUILDER_AUTH_NOT_AVAILABLE = new Error(
+    "Builder API Credentials needed to interact with this endpoint!",
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -485,4 +485,28 @@ export interface UserRewardsEarning {
     earnings: Earning[];
 }
 
-
+export interface BuilderTrade {
+    id: string;
+    tradeType: string;
+    takerOrderHash: string;
+    builder: string;
+    market: string;
+    assetId: string;
+    side: string;
+    size: string;
+    sizeUsdc: string;
+    price: string;
+    status: string;
+    outcome: string;
+    outcomeIndex: number;
+    owner: string;
+    maker: string;
+    transactionHash: string;
+    matchTime: string;
+    bucketIndex: number;
+    fee: string;
+    feeUsdc: string;
+    err_msg?: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,10 +687,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@polymarket/builder-signing-sdk@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.5.tgz#5f52cb932a04355ee3e21e80bc79b77d8fe63dd3"
-  integrity sha512-Y7YG2L9GiF6PBHYyV+qFT46MQB46XQHqmVE7+nf+eH2nLwqhqvFs9yUpyjwDtlF68o5SQdEIpPO8m8ZM9reB6g==
+"@polymarket/builder-signing-sdk@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.6.tgz#ecb674bdcc4f0b01924f861273ffceec675ec715"
+  integrity sha512-XztaELyoiYUQt0uBdhinn+VMJAGGmjxH6NGLGd5VPhgaE6fyDC0tqHWy6H9CraKEphxrkHe7wQR4BAz1xAXvBQ==
   dependencies:
     "@types/node" "^18.7.18"
     axios "^1.12.2"


### PR DESCRIPTION
* Expose `/builder/trades` endpoint on client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `getBuilderTrades` to `ClobClient` using builder auth, defines `BuilderTrade` type, introduces builder auth errors, adds `/builder/trades` endpoint, updates SDK dep, and provides an example script.
> 
> - **Client**:
>   - Add `getBuilderTrades(params?, next_cursor?)` to `ClobClient` using builder auth headers; paginated response `{ trades, next_cursor, limit, count }`.
>   - Introduce `_getBuilderHeaders` helper and import `BuilderHeaderPayload`.
>   - Add builder auth checks: `BUILDER_AUTH_NOT_AVAILABLE`, `BUILDER_AUTH_FAILED`.
> - **API/Endpoints**:
>   - Add `GET_BUILDER_TRADES = "/builder/trades"`.
> - **Types**:
>   - Define `BuilderTrade` interface; export in client usage.
> - **Examples**:
>   - New `examples/getBuilderTrades.ts` demonstrating usage.
> - **Deps/Version**:
>   - Bump `@polymarket/builder-signing-sdk` to `^0.0.6` and package version to `4.22.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ccbbdede7e2dc7f5e102931b558d389c79cf23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->