### PR TITLE
chore: remove console logging from SDK error handler

### DIFF
--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -106,12 +106,6 @@ const errorHandling = (err: unknown) => {
         }
 
         if (err.message) {
-            console.error(
-                "[CLOB Client] request error",
-                JSON.stringify({
-                    error: err.message,
-                }),
-            );
             return { error: err.message };
         }
     }


### PR DESCRIPTION
**Summary**
Remove console logging from the SDK error handler while keeping the current return based error shape.

**Changes**
- Delete all `console.error` calls in `src/http-helpers/index.ts`
- Keep returning `{ error, status }` or the original error payload when present
- No API or behavior change for consumers

**Why**
- A SDK should not log to stdout by default
- Let the consuming app decide how and where to log
- Cleaner output in server and browser environments

