### PR TITLE
Fix base64url secret decoding in HMAC signing

### DIFF
--- a/src/signing/hmac.ts
+++ b/src/signing/hmac.ts
@@ -6,7 +6,9 @@ function replaceAll(s: string, search: string, replace: string) {
  * Converts base64 string to ArrayBuffer
  */
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
-    const binaryString = atob(base64);
+    const base64Std = base64.replace(/-/g, "+").replace(/_/g, "/");
+    const normalized = base64Std + "===".slice((base64Std.length + 3) % 4);
+    const binaryString = atob(normalized);
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {
         bytes[i] = binaryString.charCodeAt(i);


### PR DESCRIPTION
## Summary
- /auth/api-key may return `secret` as base64url (may contain `_` / `-`, padding omitted).
- base64ToArrayBuffer fed it directly to `atob`, which only accepts standard base64, causing `InvalidCharacterError` when the secret includes url-safe chars.
- Normalize url-safe base64 (convert -/_ and pad to multiple of 4) before decoding so the same secret works across runtimes.

## Testing
- Node / Bun: deriveApiKey + createAndPostOrder no longer throw InvalidCharacterError.
- Standard base64 secrets still decode correctly; only input normalization changed, signature generation is otherwise unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize base64url secrets (convert -/_ and add padding) before atob in base64ToArrayBuffer to prevent decode errors.
> 
> - **Signing/HMAC**:
>   - Update `base64ToArrayBuffer` in `src/signing/hmac.ts` to normalize base64url (replace `-`/`_`, add padding) before decoding with `atob`, ensuring secrets decode consistently across runtimes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 541f904fdf06e04c87d6c7e49b2fe34f77146db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->