### PR TITLE
Update checkout action version in workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v4.1.4
+              uses: actions/checkout@v6.0.1
             - uses: actions/setup-node@v6
               with:
                   node-version: 22


### PR DESCRIPTION
Update actions/checkout to v6.0.1 for latest security patches and performance improvements.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions `actions/checkout` from `v4.1.4` to `v6.0.1` in `.github/workflows/workflow.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2dee06116d71def29c50011b9155e5dccf1a9fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->