### PR TITLE
fix: orderbook hash

### DIFF
--- a/examples/getOrderbook.ts
+++ b/examples/getOrderbook.ts
@@ -8,12 +8,12 @@ async function main() {
     const host = process.env.CLOB_API_URL || "http://localhost:8080";
     const chainId = parseInt(`${process.env.CHAIN_ID || Chain.AMOY}`) as Chain;
     const clobClient = new ClobClient(host, chainId);
-    const YES = "71321045679252212594626385532706912750332728571942532289631379312455583992563";
+    const YES = "34097058504275310827233323421517291090691602969494795225921954353603704046623";
 
     const orderbook = await clobClient.getOrderBook(YES);
     console.log("orderbook", orderbook);
 
-    const hash = clobClient.getOrderBookHash(orderbook);
+    const hash = await clobClient.getOrderBookHash(orderbook);
     console.log("orderbook hash", hash);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,6 +321,7 @@ export interface OrderBookSummary {
     min_order_size: string;
     tick_size: string;
     neg_risk: boolean;
+    last_trade_price: string;
     hash: string;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates orderbook handling and types.
> 
> - Example `getOrderbook.ts` now awaits `clobClient.getOrderBookHash(...)` and updates the sample `YES` token ID
> - Extends `OrderBookSummary` with `last_trade_price` to reflect API response
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba8110ea0122d20f96491c96ec403f3569398f53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->