### PR TITLE
Frontend Retry on Error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -162,6 +162,8 @@ export class ClobClient {
 
     readonly rfq: IRfqClient;
 
+    readonly retryOnError?: boolean;
+
     // eslint-disable-next-line max-params
     constructor(
         host: string,
@@ -173,7 +175,8 @@ export class ClobClient {
         geoBlockToken?: string,
         useServerTime?: boolean,
         builderConfig?: BuilderConfig,
-        getSigner?: () => Promise<Wallet | JsonRpcSigner> | (Wallet | JsonRpcSigner)
+        getSigner?: () => Promise<Wallet | JsonRpcSigner> | (Wallet | JsonRpcSigner),
+        retryOnError?: boolean,
     ) {
         this.host = host.endsWith("/") ? host.slice(0, -1) : host;
         this.chainId = chainId;
@@ -196,6 +199,7 @@ export class ClobClient {
         this.feeRates = {};
         this.geoBlockToken = geoBlockToken;
         this.useServerTime = useServerTime;
+        this.retryOnError = retryOnError;
         if (builderConfig !== undefined) {
             this.builderConfig = builderConfig;
         }
@@ -1372,7 +1376,7 @@ export class ClobClient {
         return post(endpoint, {
             ...options,
             params: { ...options?.params, geo_block_token: this.geoBlockToken },
-        });
+        }, this.retryOnError);
     }
 
     protected async put(endpoint: string, options?: RequestOptions) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Enhancement: optional transient-error retry for POST**
> 
> - Adds `retryOnError?` to `ClobClient` and forwards it from `client.post` to `http-helpers.post`
> - Updates `http-helpers.post` to detect transient Axios errors (network/no response, 5xx, ECONNABORTED/ENETUNREACH/EAI_AGAIN/ETIMEDOUT) and retry once after 30ms
> - `GET/PUT/DELETE` behavior unchanged; only `POST` supports the retry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1471437b8e062e76767f6247c2f0e3210b76da56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->