### PR TITLE
docs: clarify getMarkets example usage

### DIFF
--- a/examples/getMarkets.ts
+++ b/examples/getMarkets.ts
@@ -2,6 +2,8 @@ import { config as dotenvConfig } from "dotenv";
 import { resolve } from "path";
 import { Chain, ClobClient } from "../src/index.ts";
 
+// Example showcasing market-related read-only endpoints.
+// Demonstrates basic client initialization and pagination helpers.
 dotenvConfig({ path: resolve(import.meta.dirname, "../.env") });
 
 async function main() {


### PR DESCRIPTION
Adds brief documentation comments to the getMarkets example to clarify intent and usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of the `getMarkets` example.
> 
> - Adds documentation comments in `examples/getMarkets.ts` to clarify intent, usage of `ClobClient` market read-only endpoints, and basic pagination helpers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb40e1f9a6e87a4d3beba72e811d06e3f10f22be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->