### PR TITLE
[Fix Bug]: invalid amounts, the market buy orders maker amount supports a max accuracy of 2 decimals, taker amount a max of 4 decimals when post order with OrderType.GTC

### DIFF
--- a/src/order-builder/helpers.ts
+++ b/src/order-builder/helpers.ts
@@ -217,10 +217,10 @@ export const getMarketOrderRawAmounts = (
     } else {
         const rawMakerAmt = roundDown(amount, roundConfig.size);
         let rawTakerAmt = rawMakerAmt * rawPrice;
-        if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-            rawTakerAmt = roundUp(rawTakerAmt, roundConfig.amount + 4);
-            if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-                rawTakerAmt = roundDown(rawTakerAmt, roundConfig.amount);
+        if (decimalPlaces(rawTakerAmt) > roundConfig.size) {
+            rawTakerAmt = roundUp(rawTakerAmt, roundConfig.size + 4);
+            if (decimalPlaces(rawTakerAmt) > roundConfig.size) {
+                rawTakerAmt = roundDown(rawTakerAmt, roundConfig.size);
             }
         }
 


### PR DESCRIPTION
Fix error: `invalid amounts, the market buy orders maker amount supports a max accuracy of 2 decimals, taker amount a max of 4 decimals` when post order with `OrderType.GTC`

Fix incorrect rounding config in getMarketOrderRawAmounts function. rawTakerAmt represents token size, not price amount, so it should use roundConfig.size instead of roundConfig.amount for decimal precision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes rounding precision for market orders to align taker amount with token size.
> 
> - Updates `getMarketOrderRawAmounts` to round `rawTakerAmt` using `roundConfig.size` (not `roundConfig.amount`) for both BUY and SELL paths
> - Prevents precision/validation errors when posting market orders
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1343aa940716645a8e4f020ff8bcaab379bb682a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->