### PR TITLE
feat: add market id validator

### DIFF
--- a/src/utils/validateMarketId.ts
+++ b/src/utils/validateMarketId.ts
@@ -1,0 +1,7 @@
+const MARKET_ID_RE = /^[a-zA-Z0-9_-]{6,128}$/
+
+export function validateMarketId(value: string): void {
+  if (!MARKET_ID_RE.test(value)) {
+    throw new Error('Invalid market id format')
+  }
+}


### PR DESCRIPTION
Added a small validator to catch malformed IDs early instead of failing downstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a simple utility to validate market IDs.
> 
> - Adds `validateMarketId` in `src/utils/validateMarketId.ts` enforcing `/^[a-zA-Z0-9_-]{6,128}$/` and throwing `Error` on invalid input
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70f1e867bbe686e653d8308c015a655112a694c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->