### PR TITLE
Create HTTP_TIMEOUTS.md

### DIFF
--- a/docs/HTTP_TIMEOUTS.md
+++ b/docs/HTTP_TIMEOUTS.md
@@ -1,0 +1,12 @@
+# HTTP Timeouts
+
+Recommended defaults for clients calling CLOB endpoints:
+
+- Connect timeout: 3s
+- Read timeout: 10s
+- Total timeout: 15s (if supported)
+
+Retry guidance:
+- Retry only idempotent requests
+- Use exponential backoff with jitter
+- Cap retries (e.g., 3 attempts)


### PR DESCRIPTION
Documented practical timeout defaults so clients don’t hang indefinitely on bad networks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation and does not change runtime code or behavior.
> 
> **Overview**
> Adds new `docs/HTTP_TIMEOUTS.md` documenting recommended HTTP client defaults (connect/read/total timeouts) for CLOB endpoint calls, plus basic retry guidance (idempotent-only, exponential backoff with jitter, capped attempts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f849697905198ddcb3ede68ab593e75f5f3ef7bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->