### PR TITLE
feat: allow builder-authenticated clients to query orders

### DIFF
--- a/examples/getBuilderOpenOrders.ts
+++ b/examples/getBuilderOpenOrders.ts
@@ -1,0 +1,49 @@
+import { ethers } from "ethers";
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+import { type ApiKeyCreds, Chain, ClobClient } from "../src/index.ts";
+import { type BuilderApiKeyCreds, BuilderConfig } from "@polymarket/builder-signing-sdk";
+
+dotenvConfig({ path: resolve(import.meta.dirname, "../.env") });
+
+async function main() {
+    const wallet = new ethers.Wallet(`${process.env.PK}`);
+    const chainId = parseInt(`${process.env.CHAIN_ID || Chain.AMOY}`) as Chain;
+    console.log(`Address: ${await wallet.getAddress()}, chainId: ${chainId}`);
+
+    const host = process.env.CLOB_API_URL || "http://localhost:8080";
+    const creds: ApiKeyCreds = {
+        key: `${process.env.CLOB_API_KEY}`,
+        secret: `${process.env.CLOB_SECRET}`,
+        passphrase: `${process.env.CLOB_PASS_PHRASE}`,
+    };
+
+    const builderCreds: BuilderApiKeyCreds = {
+        key: `${process.env.BUILDER_API_KEY}`,
+        secret: `${process.env.BUILDER_SECRET}`,
+        passphrase: `${process.env.BUILDER_PASS_PHRASE}`,
+    };
+    const builderConfig = new BuilderConfig({
+        localBuilderCreds: builderCreds,
+    });
+    // const builderConfig = new BuilderConfig({
+    //     remoteBuilderSignerUrl: "http://localhost:8080/sign"
+    // });
+    const clobClient = new ClobClient(
+        host,
+        chainId,
+        wallet,
+        creds,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        builderConfig,
+    );
+
+    const openOrders = await clobClient.getOpenOrders();
+    console.log(openOrders);
+    console.log(`Done!`);
+}
+
+main();

--- a/src/client.ts
+++ b/src/client.ts
@@ -595,6 +595,14 @@ export class ClobClient {
             this.useServerTime ? await this.getServerTime() : undefined,
         );
 
+        // builders flow
+        if (this.canBuilderAuth()) {
+            const builderHeaders = await this._generateBuilderHeaders(headers, headerArgs);
+            if (builderHeaders !== undefined) {
+                return this.get(`${this.host}${endpoint}`, { headers: builderHeaders });
+            }
+        }
+
         return this.get(`${this.host}${endpoint}`, { headers });
     }
 
@@ -916,6 +924,15 @@ export class ClobClient {
             this.useServerTime ? await this.getServerTime() : undefined,
         );
 
+        // builders flow
+        let requestHeaders: any = headers;
+        if (this.canBuilderAuth()) {
+            const builderHeaders = await this._generateBuilderHeaders(headers, l2HeaderArgs);
+            if (builderHeaders !== undefined) {
+                requestHeaders = builderHeaders;
+            }
+        }
+
         let results: OpenOrder[] = [];
         next_cursor = next_cursor || INITIAL_CURSOR;
         while (next_cursor != END_CURSOR && (next_cursor === INITIAL_CURSOR || !only_first_page)) {
@@ -924,7 +941,7 @@ export class ClobClient {
                 next_cursor,
             };
             const response = await this.get(`${this.host}${endpoint}`, {
-                headers,
+                headers: requestHeaders,
                 params: _params,
             });
             next_cursor = response.next_cursor;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request authentication headers for order-query endpoints; incorrect header selection or builder signing failures could cause auth errors or unexpected access behavior.
> 
> **Overview**
> **Builder-authenticated clients can now query orders.** `ClobClient.getOrder()` and `ClobClient.getOpenOrders()` attempt to generate and inject builder headers (via existing builder config) and fall back to standard L2 headers when builder auth isn’t available.
> 
> Adds `examples/getBuilderOpenOrders.ts`, a runnable script showing how to configure `BuilderConfig` (local creds or remote signer) and call `getOpenOrders()` using env-based credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69e93afa9170a95d150526de05e269a4b095183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->