### PR TITLE
fix: tick size

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -311,7 +311,7 @@ export class ClobClient {
      * @param tokenID - If provided, only clears the cache for this token. Otherwise clears all.
      */
     public clearTickSizeCache(tokenID?: string): void {
-        if (tokenID) {
+        if (tokenID !== undefined) {
             delete this.tickSizes[tokenID];
             delete this.tickSizeTimestamps[tokenID];
         } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes tick-size caching behavior used for order validation, which could affect pricing checks or increase API calls if misconfigured. Scope is limited to `ClobClient` with a conservative default TTL and explicit cache invalidation.
> 
> **Overview**
> Improves tick-size correctness by turning the in-memory `tickSizes` map into a TTL-based cache (default 5 minutes, configurable via a new `tickSizeTtlMs` constructor arg) and tracking per-token cache timestamps.
> 
> `getOrderBook`/`getOrderBooks` now opportunistically refresh the tick size cache from `OrderBookSummary.tick_size`, and a new `clearTickSizeCache(tokenID?)` API allows forcing a refetch on next access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a8969eb40a4f2963ffaa824adb04c2533473c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->