### PR TITLE
fix: handle errors in API responses for tick size, negative risk, and fee rate

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -300,6 +300,9 @@ export class ClobClient {
         const result = await this.get(`${this.host}${GET_TICK_SIZE}`, {
             params: { token_id: tokenID },
         });
+        if (result.error) {
+            throw new Error(result.error);
+        }
         this.tickSizes[tokenID] = result.minimum_tick_size.toString() as TickSize;
         this.tickSizeTimestamps[tokenID] = Date.now();
 
@@ -330,6 +333,9 @@ export class ClobClient {
         const result = await this.get(`${this.host}${GET_NEG_RISK}`, {
             params: { token_id: tokenID },
         });
+        if (result.error) {
+            throw new Error(result.error);
+        }
         this.negRisk[tokenID] = result.neg_risk as boolean;
 
         return this.negRisk[tokenID];
@@ -343,6 +349,9 @@ export class ClobClient {
         const result = await this.get(`${this.host}${GET_FEE_RATE}`, {
             params: { token_id: tokenID },
         });
+        if (result.error) {
+            throw new Error(result.error);
+        }
         this.feeRates[tokenID] = result.base_fee as number;
 
         return this.feeRates[tokenID];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change that only adds error handling, but it can change runtime behavior by throwing where callers previously may have proceeded with bad/missing data.
> 
> **Overview**
> `ClobClient` now explicitly checks for `error` fields in responses from `GET_TICK_SIZE`, `GET_NEG_RISK`, and `GET_FEE_RATE` and throws an exception instead of caching/using potentially invalid values.
> 
> This changes failure behavior for `getTickSize`, `getNegRisk`, and `getFeeRateBps` to fail fast on API-reported errors, which can surface new runtime exceptions to callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d063e7da0f58ac9c7bb9bd158b38c77e78b7f90b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->