### PR TITLE
feat: support viem WalletClient in ExchangeOrderBuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "5.3.0",
+    "version": "5.4.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Polymarket/clob-client.git"
@@ -86,7 +86,6 @@
         "jsdom-global": "^3.0.2",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
-        "path": "^0.12.7",
         "prettier": "^2.7.1",
         "typescript": "^5.9.3",
         "ws": "^8.11.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       nyc:
         specifier: ^15.1.0
         version: 15.1.0
-      path:
-        specifier: ^0.12.7
-        version: 0.12.7
       prettier:
         specifier: ^2.7.1
         version: 2.8.8
@@ -1006,9 +1003,6 @@ packages:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
-  inherits@2.0.3:
-    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1299,9 +1293,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  path@0.12.7:
-    resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
-
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
@@ -1328,10 +1319,6 @@ packages:
   process-on-spawn@1.1.0:
     resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
     engines: {node: '>=8'}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -1547,9 +1534,6 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
-  util@0.10.4:
-    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -2870,8 +2854,6 @@ snapshots:
       once: 1.4.0
       wrappy: 1.0.2
 
-  inherits@2.0.3: {}
-
   inherits@2.0.4: {}
 
   is-binary-path@2.1.0:
@@ -3205,11 +3187,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  path@0.12.7:
-    dependencies:
-      process: 0.11.10
-      util: 0.10.4
-
   pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
@@ -3227,8 +3204,6 @@ snapshots:
   process-on-spawn@1.1.0:
     dependencies:
       fromentries: 1.3.2
-
-  process@0.11.10: {}
 
   proxy-from-env@1.1.0: {}
 
@@ -3409,10 +3384,6 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-
-  util@0.10.4:
-    dependencies:
-      inherits: 2.0.3
 
   uuid@8.3.2: {}
 

--- a/src/order-utils/exchange.order.builder.ts
+++ b/src/order-utils/exchange.order.builder.ts
@@ -7,7 +7,7 @@ import {
     PROTOCOL_NAME,
     PROTOCOL_VERSION,
 } from "./exchange.order.const.ts";
-import type { EIP712TypedData } from "./model/eip712.model.ts";
+import type { EIP712Object, EIP712TypedData, EIP712Types } from "./model/eip712.model.ts";
 import type {
     Order,
     OrderData,
@@ -18,13 +18,68 @@ import type {
 import { SignatureType } from "./model/signature-types.model.ts";
 import { generateOrderSalt } from "./utils.ts";
 
+type ExchangeOrderSigner = Wallet | JsonRpcSigner | WalletClientLike;
+
+interface WalletClientLike {
+    account?: {
+        address: string;
+    };
+    requestAddresses?: () => Promise<string[] | readonly string[]>;
+    signTypedData(args: unknown): Promise<string>;
+}
+
+interface ExchangeTypedDataSigner {
+    getAddress(): Promise<string>;
+    signTypedData(
+        domain: EIP712Object,
+        types: EIP712Types,
+        value: EIP712Object,
+        primaryType?: string,
+    ): Promise<string>;
+}
+
+interface EthersTypedDataSigner {
+    getAddress(): Promise<string>;
+    _signTypedData(domain: EIP712Object, types: EIP712Types, value: EIP712Object): Promise<string>;
+}
+
+const isEthersTypedDataSigner = (signer: unknown): signer is EthersTypedDataSigner =>
+    typeof (signer as EthersTypedDataSigner)._signTypedData === "function";
+
+const isWalletClientLike = (signer: unknown): signer is WalletClientLike => {
+    if (typeof signer !== "object" || signer === null) {
+        return false;
+    }
+    return typeof (signer as WalletClientLike).signTypedData === "function";
+};
+
+const getWalletClientAddress = async (walletClient: WalletClientLike): Promise<string> => {
+    const accountAddress = walletClient.account?.address;
+    if (typeof accountAddress === "string" && accountAddress.length > 0) {
+        return accountAddress;
+    }
+
+    if (typeof walletClient.requestAddresses === "function") {
+        const [address] = await walletClient.requestAddresses();
+        if (typeof address === "string" && address.length > 0) {
+            return address;
+        }
+    }
+
+    throw new Error("wallet client is missing account address");
+};
+
 export class ExchangeOrderBuilder {
+    private readonly normalizedSigner: ExchangeTypedDataSigner;
+
     constructor(
         private readonly contractAddress: string,
         private readonly chainId: number,
-        private readonly signer: Wallet | JsonRpcSigner,
+        private readonly signer: ExchangeOrderSigner,
         private readonly generateSalt = generateOrderSalt,
-    ) {}
+    ) {
+        this.normalizedSigner = this.normalizeSigner(this.signer);
+    }
 
     /**
      * Build an order object including the signature.
@@ -60,7 +115,7 @@ export class ExchangeOrderBuilder {
             signer = maker;
         }
 
-        const signerAddress = await this.signer.getAddress();
+        const signerAddress = await this.normalizedSigner.getAddress();
         if (signer !== signerAddress) {
             throw new Error("signer does not match");
         }
@@ -127,11 +182,14 @@ export class ExchangeOrderBuilder {
      * Generates order signature from EIP712 typed data.
      */
     buildOrderSignature(typedData: EIP712TypedData): Promise<OrderSignature> {
-        delete typedData.types.EIP712Domain;
-        return this.signer._signTypedData(
+        const orderTypes = { ...typedData.types };
+        delete orderTypes.EIP712Domain;
+
+        return this.normalizedSigner.signTypedData(
             typedData.domain,
-            typedData.types,
+            orderTypes,
             typedData.message,
+            typedData.primaryType,
         );
     }
 
@@ -147,5 +205,35 @@ export class ExchangeOrderBuilder {
             orderTypes as Parameters<typeof ethers.utils._TypedDataEncoder.hash>[1],
             orderTypedData.message as Parameters<typeof ethers.utils._TypedDataEncoder.hash>[2],
         );
+    }
+
+    private normalizeSigner(signer: ExchangeOrderSigner): ExchangeTypedDataSigner {
+        if (isEthersTypedDataSigner(signer)) {
+            return {
+                getAddress: async () => signer.getAddress(),
+                signTypedData: async (domain, types, value) =>
+                    signer._signTypedData(domain, types, value),
+            };
+        }
+
+        if (isWalletClientLike(signer)) {
+            return {
+                getAddress: async () => getWalletClientAddress(signer),
+                signTypedData: async (domain, types, value, primaryType) => {
+                    const account = signer.account?.address
+                        ? signer.account
+                        : await getWalletClientAddress(signer);
+                    return signer.signTypedData({
+                        account,
+                        domain,
+                        types,
+                        primaryType,
+                        message: value,
+                    });
+                },
+            };
+        }
+
+        throw new Error("unsupported signer type");
     }
 }

--- a/tests/order-utils/exchange.order.builder.test.ts
+++ b/tests/order-utils/exchange.order.builder.test.ts
@@ -1,0 +1,122 @@
+import "mocha";
+import { expect } from "chai";
+import { Wallet } from "@ethersproject/wallet";
+import {
+    ExchangeOrderBuilder,
+    SignatureType,
+    Side as OrderSide,
+} from "../../src/order-utils/index.ts";
+import type { Order, OrderData } from "../../src/order-utils/index.ts";
+
+const CHAIN_ID = 137;
+const EXCHANGE_ADDRESS = "0x0000000000000000000000000000000000000001";
+const EOA_PRIVATE_KEY =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const EXPECTED_HASH = "0xeb162c6cc7aa28ad096a7c40fb9556d41fa1730d71103ba7103589ae1f18d942";
+
+const createOrderData = (signer: string): OrderData => ({
+    maker: signer,
+    taker: "0x0000000000000000000000000000000000000000",
+    tokenId: "101",
+    makerAmount: "1000000",
+    takerAmount: "2000000",
+    side: OrderSide.BUY,
+    feeRateBps: "0",
+    nonce: "2",
+    signer,
+    expiration: "0",
+    signatureType: SignatureType.EOA,
+});
+
+describe("ExchangeOrderBuilder", () => {
+    it("signs orders with a providerless ethers wallet", async () => {
+        const wallet = new Wallet(EOA_PRIVATE_KEY);
+        const address = await wallet.getAddress();
+        const builder = new ExchangeOrderBuilder(
+            EXCHANGE_ADDRESS,
+            CHAIN_ID,
+            wallet,
+            () => "123",
+        );
+
+        const signedOrder = await builder.buildSignedOrder(createOrderData(address));
+
+        expect(signedOrder.signer).to.equal(address);
+        expect(signedOrder.salt).to.equal("123");
+        expect(signedOrder.signature).to.match(/^0x[0-9a-f]+$/i);
+    });
+
+    it("signs orders with a WalletClient-compatible signer and forwards primaryType", async () => {
+        const walletClientAddress = "0x00000000000000000000000000000000000000a1";
+        let receivedPrimaryType = "";
+        const walletClientMock = {
+            chain: { id: CHAIN_ID },
+            account: { address: walletClientAddress },
+            transport: {
+                config: {},
+                name: "mock-transport",
+                request: async (_args: { method: string; params?: unknown[] }) => null,
+                type: "custom",
+                value: {},
+            },
+            requestAddresses: async (): Promise<string[]> => [walletClientAddress],
+            signMessage: async (_args: unknown): Promise<string> => "0x01",
+            signTypedData: async (args: { primaryType: string }): Promise<string> => {
+                receivedPrimaryType = args.primaryType;
+                return "0xdeadbeef";
+            },
+            sendTransaction: async (_args: unknown): Promise<string> => "0xabc",
+        };
+        const builder = new ExchangeOrderBuilder(
+            EXCHANGE_ADDRESS,
+            CHAIN_ID,
+            walletClientMock as any,
+            () => "456",
+        );
+
+        const signedOrder = await builder.buildSignedOrder(createOrderData(walletClientAddress));
+
+        expect(signedOrder.signature).to.equal("0xdeadbeef");
+        expect(receivedPrimaryType).to.equal("Order");
+    });
+
+    it("throws when order signer does not match the signer address", async () => {
+        const wallet = new Wallet(EOA_PRIVATE_KEY);
+        const builder = new ExchangeOrderBuilder(EXCHANGE_ADDRESS, CHAIN_ID, wallet, () => "789");
+        const badOrderData = createOrderData("0x00000000000000000000000000000000000000b2");
+
+        let thrownError: unknown;
+        try {
+            await builder.buildOrder(badOrderData);
+        } catch (err) {
+            thrownError = err;
+        }
+
+        expect(thrownError).to.be.instanceOf(Error);
+        expect((thrownError as Error).message).to.equal("signer does not match");
+    });
+
+    it("builds a deterministic order hash", () => {
+        const wallet = new Wallet(EOA_PRIVATE_KEY);
+        const builder = new ExchangeOrderBuilder(EXCHANGE_ADDRESS, CHAIN_ID, wallet);
+        const order: Order = {
+            salt: "1",
+            maker: "0x1111111111111111111111111111111111111111",
+            signer: "0x1111111111111111111111111111111111111111",
+            taker: "0x0000000000000000000000000000000000000000",
+            tokenId: "101",
+            makerAmount: "1000000",
+            takerAmount: "2000000",
+            expiration: "0",
+            nonce: "2",
+            feeRateBps: "0",
+            side: OrderSide.BUY,
+            signatureType: SignatureType.EOA,
+        };
+
+        const typedData = builder.buildOrderTypedData(order);
+        const orderHash = builder.buildOrderHash(typedData);
+
+        expect(orderHash).to.equal(EXPECTED_HASH);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes order-signing behavior and signer type handling; bugs here could produce invalid signatures or mismatched signer-address checks across wallet implementations.
> 
> **Overview**
> `ExchangeOrderBuilder` now accepts either an ethers `Wallet`/`JsonRpcSigner` **or** a WalletClient-like signer (e.g., viem) by normalizing them behind a `signTypedData` + `getAddress` interface, including forwarding `primaryType` when signing typed data.
> 
> Adds tests covering signing with a providerless ethers wallet, signing via a WalletClient-compatible mock, signer/address mismatch errors, and deterministic order-hash generation. Also bumps package version to `5.4.0` and removes the unused `path` dev dependency (lockfile updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7bc2ed67a5c1aaa55c2c3c7c227319ba696eeb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->