### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     release:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
 
@@ -19,11 +19,8 @@ jobs:
                   node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
-            - name: Enable pnpm
-              run: |
-                  corepack enable
-                  corepack prepare pnpm@9.15.4 --activate
-                  pnpm -v
+            - name: pnpm setup
+              uses: pnpm/action-setup@v4
 
             - run: pnpm install --frozen-lockfile
             - run: pnpm lint

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -17,11 +17,8 @@ jobs:
                   node-version: 24
                   registry-url: "https://registry.npmjs.org"
 
-            - name: Enable pnpm
-              run: |
-                  corepack enable
-                  corepack prepare pnpm@9.15.4 --activate
-                  pnpm -v
+            - name: pnpm setup
+              uses: pnpm/action-setup@v4
 
             - run: pnpm install --frozen-lockfile
             - run: pnpm lint

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ Typescript client for the Polymarket CLOB
 ### Usage
 
 ```ts
-//npm install @polymarket/clob-client
-//npm install ethers
-//Client initialization example and dumping API Keys
+// npm install @polymarket/clob-client
+// npm install ethers
+// Client initialization example and dumping API Keys
 
 import { ApiKeyCreds, ClobClient, OrderType, Side, } from "@polymarket/clob-client";
 import { Wallet } from "@ethersproject/wallet";
 
 const host = 'https://clob.polymarket.com';
-const funder = '';//This is your Polymarket Profile Address, where you send UDSC to. 
-const signer = new Wallet(""); //This is your Private Key. If using email login export from https://reveal.magic.link/polymarket otherwise export from your Web3 Application
+const funder = ''; // This is your Polymarket Profile Address, where you send UDSC to. 
+const signer = new Wallet(""); // This is your Private Key. If using email login export from https://reveal.magic.link/polymarket otherwise export from your Web3 Application
 
 
-//In general don't create a new API key, always derive or createOrDerive
+// In general don't create a new API key, always derive or createOrDerive
 const creds = new ClobClient(host, 137, signer).createOrDeriveApiKey();
 
 //0: Browser Wallet(Metamask, Coinbase Wallet, etc)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "5.6.0",
+    "version": "5.7.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Polymarket/clob-client.git"
@@ -51,7 +51,7 @@
         "node": ">=20.10"
     },
     "license": "MIT",
-    "packageManager": "pnpm@9.15.4",
+    "packageManager": "pnpm@10.30.3",
     "scripts": {
         "build": "rm -rf dist && tsc -p tsconfig.build.json",
         "typecheck": "tsc -p tsconfig.test.json --noEmit",
@@ -64,7 +64,6 @@
         "@polymarket/builder-signing-sdk": "^0.0.8",
         "axios": "^1.0.0",
         "browser-or-node": "^2.1.1",
-        "tslib": "^2.8.1",
         "viem": "^2.46.3"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       browser-or-node:
         specifier: ^2.1.1
         version: 2.1.1
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       viem:
         specifier: ^2.46.3
         version: 2.46.3(typescript@5.9.3)

--- a/src/order-builder/builder.ts
+++ b/src/order-builder/builder.ts
@@ -41,7 +41,7 @@ export class OrderBuilder {
     }
 
     /**
-     * Generate and sign a order
+     * Generate and sign an order
      */
     public async buildOrder(
         userOrder: UserOrder,

--- a/src/order-builder/helpers.ts
+++ b/src/order-builder/helpers.ts
@@ -44,7 +44,7 @@ export const ROUNDING_CONFIG: Record<TickSize, RoundConfig> = {
 };
 
 /**
- * Generate and sign a order
+ * Generate and sign an order
  *
  * @param signer
  * @param exchangeAddress ctf exchange contract address

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
-        "importHelpers": true,
         "rewriteRelativeImportExtensions": true,
         "strict": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Summary

- **Fix release CI**: Switch back to GitHub runners to pass npm's provenance check
- **Fix CI pnpm setup**: Replace manual `corepack enable && corepack prepare` steps with the official `pnpm/action-setup@v4` action in both `workflow.yaml` and `release.yaml`, which is more reliable and the recommended approach.
- **Update `release.yaml` runner**: Switch from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest`.
- **Bump pnpm to v10**: Update `packageManager` from `pnpm@9.15.4` to `pnpm@10.30.3`.
- **Drop unused `tslib` dependency**: Remove `tslib` from dependencies and the corresponding `importHelpers` tsconfig option. With `target: "es2022"`, TypeScript emits no runtime helpers, making `tslib` dead weight.
- **Version bump**: `5.6.0` → `5.7.0`.

## Why

Fixes a [422 error](https://github.com/Polymarket/clob-client/actions/runs/22681944431/job/65754546566) on the release action.

Using a GitHub-hosted runner fixes this by passing the provenance check.

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1031230408
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@polymarket%2fclob-client - Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-03-04T17_54_38_988Z-debug-0.log
Error: Process completed with exit code 1.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI/tooling changes plus removal of an unused dependency; minimal impact on runtime behavior, with the main risk being CI/environment differences affecting builds/releases.
> 
> **Overview**
> Fixes npm provenance publishing in the release workflow by switching the release job runner to GitHub-hosted `ubuntu-latest` and replacing manual `corepack` pnpm bootstrapping with `pnpm/action-setup@v4` (also applied to the main CI workflow).
> 
> Bumps the package version to `5.7.0`, updates the pinned `packageManager` to pnpm v10, removes the unused `tslib` dependency and `tsconfig.json` `importHelpers` flag, and includes small comment/README wording cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 484bd06deff7f3a4338674bf2bf0de99dd1dec96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->