### PR TITLE
test: add TTL cache behavior tests for tick size validation

### DIFF
--- a/tests/client/tick-size-cache.test.ts
+++ b/tests/client/tick-size-cache.test.ts
@@ -1,0 +1,88 @@
+import { ClobClient } from "../../src/client.ts";
+import { Chain } from "../../src/types.ts";
+
+class TestableClient extends ClobClient {
+    public getCallCount = 0;
+    public nextTickSize = "0.01";
+
+    protected async get(_endpoint: string, _options?: any): Promise<any> {
+        this.getCallCount++;
+        return { minimum_tick_size: this.nextTickSize };
+    }
+}
+
+describe("tick size cache TTL", () => {
+    const host = "http://localhost";
+    const chainId = Chain.AMOY;
+    const tokenID = "token-abc";
+
+    it("returns cached value within TTL without refetching", async () => {
+        const client = new TestableClient(host, chainId);
+        await client.getTickSize(tokenID);
+        await client.getTickSize(tokenID);
+        expect(client.getCallCount).to.equal(1);
+    });
+
+    it("refetches after TTL expires", async () => {
+        // TTL of 1ms so any await causes expiry
+        const client = new TestableClient(
+            host,
+            chainId,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            1,
+        );
+        await client.getTickSize(tokenID);
+        await new Promise(r => setTimeout(r, 5));
+        await client.getTickSize(tokenID);
+        expect(client.getCallCount).to.equal(2);
+    });
+
+    it("picks up updated tick size after TTL expires", async () => {
+        const client = new TestableClient(
+            host,
+            chainId,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            1,
+        );
+        client.nextTickSize = "0.01";
+        await client.getTickSize(tokenID);
+        await new Promise(r => setTimeout(r, 5));
+        client.nextTickSize = "0.001";
+        const result = await client.getTickSize(tokenID);
+        expect(result).to.equal("0.001");
+    });
+
+    it("clearTickSizeCache forces refetch for specific token", async () => {
+        const client = new TestableClient(host, chainId);
+        await client.getTickSize(tokenID);
+        client.clearTickSizeCache(tokenID);
+        await client.getTickSize(tokenID);
+        expect(client.getCallCount).to.equal(2);
+    });
+
+    it("clearTickSizeCache with no arg clears all tokens", async () => {
+        const client = new TestableClient(host, chainId);
+        await client.getTickSize("token-1");
+        await client.getTickSize("token-2");
+        client.clearTickSizeCache();
+        await client.getTickSize("token-1");
+        await client.getTickSize("token-2");
+        expect(client.getCallCount).to.equal(4);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds 5 tests covering the tick size cache TTL behavior introduced in #299
- Validates the exact regression scenario from #265 (cached `0.01` → updated `0.001` after TTL expiry)
- Tests `clearTickSizeCache` for both per-token and full cache invalidation

## Tests added

1. Returns cached value within TTL without refetching
2. Refetches after TTL expires
3. Picks up updated tick size after TTL expires (the #265 regression)
4. `clearTickSizeCache` forces refetch for specific token
5. `clearTickSizeCache` with no arg clears all tokens

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 179/179 pass
- [x] New tests: 5/5 pass in 15ms

Relates to #265

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds isolated unit tests only, exercising existing tick size caching/TTL and `clearTickSizeCache` behavior without changing production logic.
> 
> **Overview**
> Adds a new `tick-size-cache.test.ts` suite that verifies `ClobClient.getTickSize` respects the tick-size cache TTL (no refetch within TTL, refetch and value update after expiry).
> 
> Also adds coverage for `clearTickSizeCache`, asserting both per-token and full-cache invalidation force subsequent refetches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7892c700b72b59fc32dc014de1f2a269a2a70e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->