### PR TITLE
fix(http): redact sensitive request config in error logs

### DIFF
--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -133,6 +133,18 @@ export const put = async (endpoint: string, options?: RequestOptions): Promise<a
     }
 };
 
+export const sanitizeAxiosResponseConfig = (config: unknown) => {
+    if (!config || typeof config !== "object") {
+        return undefined;
+    }
+    const maybe = config as Record<string, unknown>;
+    return {
+        method: maybe.method,
+        url: maybe.url,
+        timeout: maybe.timeout,
+    };
+};
+
 const errorHandling = (err: unknown) => {
     if (axios.isAxiosError(err)) {
         if (err.response) {
@@ -142,7 +154,7 @@ const errorHandling = (err: unknown) => {
                     status: err.response?.status,
                     statusText: err.response?.statusText,
                     data: err.response?.data,
-                    config: err.response?.config,
+                    config: sanitizeAxiosResponseConfig(err.response?.config),
                 }),
             );
             if (err.response?.data) {

--- a/tests/http-helpers/index.test.ts
+++ b/tests/http-helpers/index.test.ts
@@ -1,6 +1,7 @@
 import {
     parseDropNotificationParams,
     parseOrdersScoringParams,
+    sanitizeAxiosResponseConfig,
 } from "../../src/http-helpers/index.ts";
 import type { DropNotificationParams, OrdersScoringParams } from "../../src/types.ts";
 
@@ -25,6 +26,23 @@ describe("utilities", () => {
             expect(params).not.undefined;
             expect(params).not.empty;
             expect(params).deep.equal({ ids: "0,1,2" });
+        });
+    });
+
+    describe("sanitizeAxiosResponseConfig", () => {
+        it("removes sensitive headers and auth details", () => {
+            const sanitized = sanitizeAxiosResponseConfig({
+                method: "post",
+                url: "https://clob.polymarket.com/order",
+                timeout: 5000,
+                headers: { Authorization: "Bearer secret" },
+                auth: { username: "u", password: "p" },
+            });
+            expect(sanitized).deep.equal({
+                method: "post",
+                url: "https://clob.polymarket.com/order",
+                timeout: 5000,
+            });
         });
     });
 });


### PR DESCRIPTION
Fixes #327

## What changed
- Stop logging raw `err.response.config` in HTTP helper error paths.
- Add `sanitizeAxiosResponseConfig()` to only keep safe fields (`method`, `url`, `timeout`).
- Add unit test to ensure sensitive fields like `headers` and `auth` are not exposed.

## Why
The previous error logging could leak authorization material via request config dumps in logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limits error-log output to a small allowlist and adds a unit test; behavior changes are confined to logging and should not affect request/response handling.
> 
> **Overview**
> Updates HTTP helper error logging to stop dumping raw Axios `response.config` (which may include auth/headers) and instead log a sanitized subset via new `sanitizeAxiosResponseConfig()`.
> 
> Adds a unit test to assert only `method`, `url`, and `timeout` are retained and sensitive fields like `headers`/`auth` are excluded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a946e5db228ac2117c0eda8daeecde20dcd74030. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->