### PR TITLE
types(client): return typed order responses instead of any

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -114,6 +114,7 @@ import type {
     OrderBookSummary,
     OrderMarketCancelParams,
     OrderPayload,
+    OrderResponse,
     OrderScoring,
     OrderScoringParams,
     OrdersScoring,
@@ -936,7 +937,7 @@ export class ClobClient {
         orderType: T = OrderType.GTC as T,
         deferExec = false,
         postOnly = false,
-    ): Promise<any> {
+    ): Promise<OrderResponse> {
         const order = await this.createOrder(userOrder, options);
         return this.postOrder(order, orderType, deferExec, postOnly);
     }
@@ -946,7 +947,7 @@ export class ClobClient {
         options?: Partial<CreateOrderOptions>,
         orderType: T = OrderType.FOK as T,
         deferExec = false,
-    ): Promise<any> {
+    ): Promise<OrderResponse> {
         const order = await this.createMarketOrder(userMarketOrder, options);
         return this.postOrder(order, orderType, deferExec);
     }
@@ -1001,7 +1002,7 @@ export class ClobClient {
         orderType: T = OrderType.GTC as T,
         deferExec = false,
         postOnly = false,
-    ): Promise<any> {
+    ): Promise<OrderResponse> {
         this.canL2Auth();
         const endpoint = POST_ORDER;
         const orderPayload = orderToJson(
@@ -1043,7 +1044,7 @@ export class ClobClient {
         args: PostOrdersArgs[],
         deferExec = false,
         defaultPostOnly = false,
-    ): Promise<any> {
+    ): Promise<OrderResponse[]> {
         this.canL2Auth();
         const endpoint = POST_ORDERS;
         const ordersPayload: NewOrder<any>[] = [];


### PR DESCRIPTION
Addresses #307

## What changed
- Replaced `any` return types in order-posting APIs with explicit types:
  - `postOrder` -> `Promise<OrderResponse>`
  - `postOrders` -> `Promise<OrderResponse[]>`
  - `createAndPostOrder` -> `Promise<OrderResponse>`
  - `createAndPostMarketOrder` -> `Promise<OrderResponse>`

## Why
This improves TypeScript ergonomics and safety for SDK consumers by exposing concrete response shapes instead of `any`.

## Validation
- `pnpm lint`
- `pnpm build`
- `vitest run tests/utilities.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk; changes are TypeScript return-type annotations for order-posting methods and should not affect runtime behavior, but may require downstream callers to align with the `OrderResponse` shape.
> 
> **Overview**
> Updates the client order submission APIs to return explicit response types instead of `any`. `postOrder`, `postOrders`, `createAndPostOrder`, and `createAndPostMarketOrder` now return `OrderResponse`/`OrderResponse[]`, exposing a concrete response contract (e.g., `success`, `errorMsg`, `orderID`, `transactionsHashes`, `status`, amounts) for SDK consumers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436d3c637527bf3a76035625e0766a40c151ec92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->