### PR TITLE
feat: abstract away wallet type specification with auto-detection

### DIFF
--- a/examples/signatureTypes.ts
+++ b/examples/signatureTypes.ts
@@ -17,10 +17,12 @@ async function main() {
         passphrase: `${process.env.CLOB_PASS_PHRASE}`,
     };
 
-    // Client used with an EOA: Signature type 0
+    // ─── Option A: Explicit wallet type (existing API, still works) ───
+
+    // EOA: Signature type 0
     const clobClient = new ClobClient(host, chainId, wallet, creds);
 
-    // Client used with a Polymarket Proxy Wallet: Signature type 1
+    // Polymarket Proxy Wallet: Signature type 1
     const proxyWalletAddress = "0x...";
     const polyProxyClient = new ClobClient(
         host,
@@ -31,7 +33,7 @@ async function main() {
         proxyWalletAddress,
     );
 
-    // Client used with a Polymarket Gnosis safe: Signature Type 2
+    // Polymarket Gnosis Safe: Signature type 2
     const gnosisSafeAddress = "0x...";
     const polyGnosisSafeClient = new ClobClient(
         host,
@@ -42,9 +44,33 @@ async function main() {
         gnosisSafeAddress,
     );
 
+    // ─── Option B: Auto-detect wallet type (new API) ───
+    // Just provide the funderAddress (your Polymarket wallet) and an RPC URL.
+    // The SDK figures out whether it's a Proxy or a Safe automatically.
+
+    const polymarketWallet = "0x..."; // your address from polymarket.com/settings
+    const autoDetectedClient = await ClobClient.create({
+        host,
+        chainId,
+        signer: wallet,
+        creds,
+        funderAddress: polymarketWallet,
+        rpcUrl: "https://polygon-rpc.com",
+    });
+
+    // EOA usage with ClobClient.create() — no funderAddress needed
+    const eaoClient = await ClobClient.create({
+        host,
+        chainId,
+        signer: wallet,
+        creds,
+    });
+
     void clobClient;
     void polyProxyClient;
     void polyGnosisSafeClient;
+    void autoDetectedClient;
+    void eaoClient;
 }
 
 main();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import type { BuilderConfig, BuilderHeaderPayload } from "@polymarket/builder-signing-sdk";
+import type { PublicClient } from "viem";
 import { END_CURSOR, INITIAL_CURSOR } from "./constants.ts";
 import {
     ARE_ORDERS_SCORING,
@@ -83,6 +84,7 @@ import type { SignatureType, SignedOrder } from "./order-utils/index.ts";
 import { RfqClient } from "./rfq-client.ts";
 import type { IRfqClient, RfqDeps } from "./rfq-deps.ts";
 import type { ClobSigner } from "./signer.ts";
+import { getSignerAddress } from "./signer.ts";
 import type {
     ApiKeyCreds,
     ApiKeyRaw,
@@ -140,6 +142,48 @@ import {
     orderToJson,
     priceValid,
 } from "./utilities.ts";
+import type { WalletDetectionResult } from "./wallet-detection.ts";
+import { resolveWalletConfig } from "./wallet-detection.ts";
+
+/**
+ * Configuration object for {@link ClobClient.create}.
+ *
+ * When `funderAddress` is provided but `signatureType` is omitted, the
+ * factory method will auto-detect the wallet type via an on-chain call.
+ * This requires either `rpcUrl` or `publicClient` to be set.
+ */
+export interface ClobClientConfig {
+    host: string;
+    chainId: Chain;
+    signer?: ClobSigner;
+    creds?: ApiKeyCreds;
+
+    /**
+     * Explicit wallet type. When omitted and `funderAddress` differs from
+     * the signer address, auto-detection is attempted.
+     */
+    signatureType?: SignatureType;
+
+    /**
+     * The smart-contract wallet that holds funds (proxy or Safe address).
+     * Omit for plain EOA wallets.
+     */
+    funderAddress?: string;
+
+    /** JSON-RPC URL used for on-chain wallet-type detection. */
+    rpcUrl?: string;
+
+    /** Pre-configured viem PublicClient for on-chain wallet-type detection. */
+    publicClient?: PublicClient;
+
+    geoBlockToken?: string;
+    useServerTime?: boolean;
+    builderConfig?: BuilderConfig;
+    getSigner?: () => Promise<ClobSigner> | ClobSigner;
+    retryOnError?: boolean;
+    tickSizeTtlMs?: number;
+    throwOnError?: boolean;
+}
 
 export class ClobClient {
     readonly host: string;
@@ -239,6 +283,58 @@ export class ClobClient {
         };
 
         this.rfq = new RfqClient(rfqDeps);
+    }
+
+    /**
+     * Async factory that auto-detects the wallet type when `signatureType`
+     * is omitted and a `funderAddress` is provided.
+     *
+     * For plain EOA usage (no proxy/safe), this behaves identically to the
+     * constructor — no RPC call is made.
+     *
+     * @example
+     * ```ts
+     * // Auto-detect: provide funderAddress + rpcUrl, omit signatureType
+     * const client = await ClobClient.create({
+     *     host: "https://clob.polymarket.com",
+     *     chainId: 137,
+     *     signer: wallet,
+     *     creds,
+     *     funderAddress: "0xMyPolymarketWallet...",
+     *     rpcUrl: "https://polygon-rpc.com",
+     * });
+     * ```
+     */
+    static async create(config: ClobClientConfig): Promise<ClobClient> {
+        let { signatureType, funderAddress } = config;
+
+        if (signatureType === undefined && config.signer) {
+            const signerAddress = await getSignerAddress(config.signer);
+            const resolved: WalletDetectionResult = await resolveWalletConfig(signerAddress, {
+                funderAddress,
+                signatureType,
+                clientOrUrl: config.publicClient ?? config.rpcUrl,
+                chainId: config.chainId,
+            });
+            signatureType = resolved.signatureType;
+            funderAddress = resolved.funderAddress;
+        }
+
+        return new ClobClient(
+            config.host,
+            config.chainId,
+            config.signer,
+            config.creds,
+            signatureType,
+            funderAddress,
+            config.geoBlockToken,
+            config.useServerTime,
+            config.builderConfig,
+            config.getSigner,
+            config.retryOnError,
+            config.tickSizeTtlMs,
+            config.throwOnError,
+        );
     }
 
     // Public endpoints

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,5 @@ export * from "./rfq-client.ts";
 export * from "./rfq-deps.ts";
 export type { ClobSigner } from "./signer.ts";
 export * from "./types.ts";
+export type { WalletDetectionResult } from "./wallet-detection.ts";
+export { detectWalletType, resolveWalletConfig } from "./wallet-detection.ts";

--- a/src/wallet-detection.ts
+++ b/src/wallet-detection.ts
@@ -1,0 +1,121 @@
+import { type Address, createPublicClient, getAddress, http, type PublicClient } from "viem";
+import { polygon, polygonAmoy } from "viem/chains";
+import { SignatureType } from "./order-utils/index.ts";
+import type { Chain } from "./types.ts";
+
+export interface WalletDetectionResult {
+    signatureType: SignatureType;
+    funderAddress: string;
+}
+
+const GNOSIS_SAFE_GET_OWNERS_SELECTOR = "0xa0e67e2b" as const;
+
+function getViemChain(chainId: Chain) {
+    switch (chainId) {
+        case 137:
+            return polygon;
+        case 80002:
+            return polygonAmoy;
+        default:
+            throw new Error(`Unsupported chainId for wallet detection: ${chainId}`);
+    }
+}
+
+function ensurePublicClient(clientOrUrl: PublicClient | string, chainId?: Chain): PublicClient {
+    if (typeof clientOrUrl === "string") {
+        if (chainId === undefined) {
+            throw new Error("chainId is required when providing an rpcUrl string");
+        }
+        return createPublicClient({
+            chain: getViemChain(chainId),
+            transport: http(clientOrUrl),
+        });
+    }
+    return clientOrUrl;
+}
+
+/**
+ * Detects whether a smart-contract wallet is a Polymarket Gnosis Safe or a
+ * Polymarket Proxy by inspecting on-chain bytecode behaviour.
+ *
+ * Works by calling the Gnosis Safe `getOwners()` function on the address.
+ * If the call returns data the wallet is a Safe; otherwise it is assumed to
+ * be a Polymarket Proxy.
+ *
+ * @param funderAddress - The smart-contract wallet address to classify.
+ * @param clientOrUrl   - A viem `PublicClient` **or** an RPC URL string.
+ * @param chainId       - Required when `clientOrUrl` is a string.
+ * @returns The matching `SignatureType`.
+ */
+export async function detectWalletType(
+    funderAddress: string,
+    clientOrUrl: PublicClient | string,
+    chainId?: Chain,
+): Promise<SignatureType> {
+    const client = ensurePublicClient(clientOrUrl, chainId);
+    const addr = getAddress(funderAddress) as Address;
+
+    const code = await client.getCode({ address: addr });
+    if (!code || code === "0x") {
+        throw new Error(
+            `No contract deployed at ${funderAddress}. ` +
+                "If this is a plain EOA, omit the funderAddress parameter.",
+        );
+    }
+
+    try {
+        const result = await client.call({
+            to: addr,
+            data: GNOSIS_SAFE_GET_OWNERS_SELECTOR,
+        });
+        if (result.data && result.data.length > 2) {
+            return SignatureType.POLY_GNOSIS_SAFE;
+        }
+    } catch {
+        // getOwners() reverted → not a Safe
+    }
+
+    return SignatureType.POLY_PROXY;
+}
+
+/**
+ * Resolves the full wallet configuration for a signer.
+ *
+ * When `funderAddress` is supplied but `signatureType` is not, the function
+ * auto-detects the wallet type via an on-chain check (requires `clientOrUrl`).
+ *
+ * @returns `{ signatureType, funderAddress }` ready to pass into the
+ *          `ClobClient` constructor or `OrderBuilder`.
+ */
+export async function resolveWalletConfig(
+    signerAddress: string,
+    options: {
+        funderAddress?: string;
+        signatureType?: SignatureType;
+        clientOrUrl?: PublicClient | string;
+        chainId?: Chain;
+    },
+): Promise<WalletDetectionResult> {
+    const { funderAddress, signatureType, clientOrUrl, chainId } = options;
+
+    if (signatureType !== undefined) {
+        return {
+            signatureType,
+            funderAddress: funderAddress ?? signerAddress,
+        };
+    }
+
+    if (!funderAddress || getAddress(funderAddress) === getAddress(signerAddress)) {
+        return { signatureType: SignatureType.EOA, funderAddress: signerAddress };
+    }
+
+    if (!clientOrUrl) {
+        throw new Error(
+            "Cannot auto-detect wallet type without an RPC connection. " +
+                "Provide signatureType explicitly, or pass an rpcUrl / publicClient.",
+        );
+    }
+
+    const detected = await detectWalletType(funderAddress, clientOrUrl, chainId);
+    return { signatureType: detected, funderAddress };
+}

--- a/tests/client/create-factory.test.ts
+++ b/tests/client/create-factory.test.ts
@@ -1,0 +1,67 @@
+import { ClobClient } from "../../src/client.ts";
+import { SignatureType } from "../../src/order-utils/index.ts";
+import { Chain } from "../../src/types.ts";
+import type { ApiKeyCreds } from "../../src/types.ts";
+import type { WalletClient } from "viem";
+
+describe("ClobClient.create factory method", () => {
+    const host = "http://localhost";
+    const chainId = Chain.AMOY;
+    const signerAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+    const walletClientMock = {
+        account: { address: signerAddress },
+        signTypedData: async (_args: unknown): Promise<string> => "0xdeadbeef",
+    } as unknown as WalletClient;
+
+    const creds: ApiKeyCreds = {
+        key: "test-key",
+        secret: "test-secret",
+        passphrase: "test-passphrase",
+    };
+
+    it("creates an EOA client when no funderAddress is provided", async () => {
+        const client = await ClobClient.create({
+            host,
+            chainId,
+            signer: walletClientMock,
+            creds,
+        });
+
+        expect(client).toBeInstanceOf(ClobClient);
+        expect(client.orderBuilder.signatureType).toBe(SignatureType.EOA);
+    });
+
+    it("creates a client with explicit signatureType", async () => {
+        const funder = "0x0000000000000000000000000000000000000042";
+        const client = await ClobClient.create({
+            host,
+            chainId,
+            signer: walletClientMock,
+            creds,
+            signatureType: SignatureType.POLY_PROXY,
+            funderAddress: funder,
+        });
+
+        expect(client).toBeInstanceOf(ClobClient);
+        expect(client.orderBuilder.signatureType).toBe(SignatureType.POLY_PROXY);
+        expect(client.orderBuilder.funderAddress).toBe(funder);
+    });
+
+    it("creates a client without a signer", async () => {
+        const client = await ClobClient.create({ host, chainId });
+        expect(client).toBeInstanceOf(ClobClient);
+    });
+
+    it("throws when funderAddress differs from signer but no RPC is available", async () => {
+        await expect(
+            ClobClient.create({
+                host,
+                chainId,
+                signer: walletClientMock,
+                creds,
+                funderAddress: "0x0000000000000000000000000000000000000042",
+            }),
+        ).rejects.toThrow("Cannot auto-detect wallet type without an RPC connection");
+    });
+});

--- a/tests/wallet-detection/wallet-detection.test.ts
+++ b/tests/wallet-detection/wallet-detection.test.ts
@@ -1,0 +1,187 @@
+import type { PublicClient } from "viem";
+import { SignatureType } from "../../src/order-utils/index.ts";
+import { Chain } from "../../src/types.ts";
+import { detectWalletType, resolveWalletConfig } from "../../src/wallet-detection.ts";
+
+const GNOSIS_SAFE_GET_OWNERS_SELECTOR = "0xa0e67e2b";
+
+function mockPublicClient(overrides: {
+    getCode?: (args: { address: string }) => Promise<string | undefined>;
+    call?: (args: { to: string; data: string }) => Promise<{ data?: string }>;
+}): PublicClient {
+    return {
+        getCode: overrides.getCode ?? (async () => "0x1234"),
+        call: overrides.call ?? (async () => ({ data: undefined })),
+    } as unknown as PublicClient;
+}
+
+describe("detectWalletType", () => {
+    it("throws when no code is deployed at the address", async () => {
+        const client = mockPublicClient({
+            getCode: async () => "0x",
+        });
+
+        await expect(
+            detectWalletType("0x0000000000000000000000000000000000000001", client),
+        ).rejects.toThrow("No contract deployed");
+    });
+
+    it("throws when getCode returns undefined", async () => {
+        const client = mockPublicClient({
+            getCode: async () => undefined,
+        });
+
+        await expect(
+            detectWalletType("0x0000000000000000000000000000000000000001", client),
+        ).rejects.toThrow("No contract deployed");
+    });
+
+    it("returns POLY_GNOSIS_SAFE when getOwners() returns data", async () => {
+        const ownersResponseData =
+            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async (args) => {
+                expect(args.data).toBe(GNOSIS_SAFE_GET_OWNERS_SELECTOR);
+                return { data: ownersResponseData };
+            },
+        });
+
+        const result = await detectWalletType(
+            "0x0000000000000000000000000000000000000001",
+            client,
+        );
+        expect(result).toBe(SignatureType.POLY_GNOSIS_SAFE);
+    });
+
+    it("returns POLY_PROXY when getOwners() call reverts", async () => {
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async () => {
+                throw new Error("execution reverted");
+            },
+        });
+
+        const result = await detectWalletType(
+            "0x0000000000000000000000000000000000000001",
+            client,
+        );
+        expect(result).toBe(SignatureType.POLY_PROXY);
+    });
+
+    it("returns POLY_PROXY when getOwners() returns empty data", async () => {
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async () => ({ data: "0x" }),
+        });
+
+        const result = await detectWalletType(
+            "0x0000000000000000000000000000000000000001",
+            client,
+        );
+        expect(result).toBe(SignatureType.POLY_PROXY);
+    });
+
+    it("returns POLY_PROXY when getOwners() returns no data field", async () => {
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async () => ({}),
+        });
+
+        const result = await detectWalletType(
+            "0x0000000000000000000000000000000000000001",
+            client,
+        );
+        expect(result).toBe(SignatureType.POLY_PROXY);
+    });
+
+    it("throws when rpcUrl is given without chainId", async () => {
+        await expect(
+            detectWalletType(
+                "0x0000000000000000000000000000000000000001",
+                "https://polygon-rpc.com",
+            ),
+        ).rejects.toThrow("chainId is required");
+    });
+});
+
+describe("resolveWalletConfig", () => {
+    const signerAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+    it("returns EOA when no funderAddress is provided", async () => {
+        const result = await resolveWalletConfig(signerAddress, {});
+        expect(result.signatureType).toBe(SignatureType.EOA);
+        expect(result.funderAddress).toBe(signerAddress);
+    });
+
+    it("returns EOA when funderAddress equals signerAddress", async () => {
+        const result = await resolveWalletConfig(signerAddress, {
+            funderAddress: signerAddress,
+        });
+        expect(result.signatureType).toBe(SignatureType.EOA);
+        expect(result.funderAddress).toBe(signerAddress);
+    });
+
+    it("uses explicit signatureType when provided", async () => {
+        const funder = "0x0000000000000000000000000000000000000042";
+        const result = await resolveWalletConfig(signerAddress, {
+            funderAddress: funder,
+            signatureType: SignatureType.POLY_PROXY,
+        });
+        expect(result.signatureType).toBe(SignatureType.POLY_PROXY);
+        expect(result.funderAddress).toBe(funder);
+    });
+
+    it("uses signerAddress as funderAddress when signatureType is explicit but funder is omitted", async () => {
+        const result = await resolveWalletConfig(signerAddress, {
+            signatureType: SignatureType.EOA,
+        });
+        expect(result.signatureType).toBe(SignatureType.EOA);
+        expect(result.funderAddress).toBe(signerAddress);
+    });
+
+    it("throws when funderAddress differs from signer but no RPC is available", async () => {
+        await expect(
+            resolveWalletConfig(signerAddress, {
+                funderAddress: "0x0000000000000000000000000000000000000042",
+            }),
+        ).rejects.toThrow("Cannot auto-detect wallet type without an RPC connection");
+    });
+
+    it("auto-detects POLY_GNOSIS_SAFE via RPC", async () => {
+        const funder = "0x0000000000000000000000000000000000000042";
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async () => ({
+                data: "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            }),
+        });
+
+        const result = await resolveWalletConfig(signerAddress, {
+            funderAddress: funder,
+            clientOrUrl: client,
+            chainId: Chain.POLYGON,
+        });
+        expect(result.signatureType).toBe(SignatureType.POLY_GNOSIS_SAFE);
+        expect(result.funderAddress).toBe(funder);
+    });
+
+    it("auto-detects POLY_PROXY via RPC", async () => {
+        const funder = "0x0000000000000000000000000000000000000042";
+        const client = mockPublicClient({
+            getCode: async () => "0xabcdef",
+            call: async () => {
+                throw new Error("execution reverted");
+            },
+        });
+
+        const result = await resolveWalletConfig(signerAddress, {
+            funderAddress: funder,
+            clientOrUrl: client,
+            chainId: Chain.POLYGON,
+        });
+        expect(result.signatureType).toBe(SignatureType.POLY_PROXY);
+        expect(result.funderAddress).toBe(funder);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds wallet type auto-detection so users no longer need to manually specify whether their wallet is a Polymarket Proxy or Gnosis Safe. Previously, creating a client with a smart-contract wallet required knowing and passing both `signatureType` and `funderAddress`:

```typescript
// Before: must know the exact wallet type
const client = new ClobClient(
    host, chainId, wallet, creds,
    SignatureType.POLY_GNOSIS_SAFE,  // how do I know this?
    safeAddress,
);
```

Now users can use the new `ClobClient.create()` factory method which auto-detects the wallet type from an on-chain check:

```typescript
// After: just provide funderAddress + RPC, SDK figures out the type
const client = await ClobClient.create({
    host,
    chainId,
    signer: wallet,
    creds,
    funderAddress: "0xMyPolymarketWallet...",
    rpcUrl: "https://polygon-rpc.com",
});
```

## How It Works

The detection works by calling the Gnosis Safe `getOwners()` function selector (`0xa0e67e2b`) on the funder address:
- If the call returns data → it's a **Gnosis Safe** (`POLY_GNOSIS_SAFE`)
- If the call reverts or returns empty → it's a **Polymarket Proxy** (`POLY_PROXY`)
- If no code exists at the address → error with helpful message
- If no `funderAddress` or it matches the signer → **EOA** (no RPC call needed)

This approach is robust against factory init code hash changes (which have caused issues with CREATE2 derivation in the Rust SDK).

## Changes

### New: `src/wallet-detection.ts`
- `detectWalletType(funderAddress, clientOrUrl, chainId?)` — low-level detection
- `resolveWalletConfig(signerAddress, options)` — high-level resolver handling all cases
- `WalletDetectionResult` type

### Modified: `src/client.ts`
- `ClobClientConfig` interface — typed config object (cleaner than 13 positional params)
- `ClobClient.create(config)` — async factory method with auto-detection
- Fully backward compatible: existing constructor is unchanged

### Modified: `src/index.ts`
- Exports `detectWalletType`, `resolveWalletConfig`, `WalletDetectionResult`, `ClobClientConfig`

### Updated: `examples/signatureTypes.ts`
- Shows both the existing explicit API and the new auto-detection flow

### New Tests
- `tests/wallet-detection/wallet-detection.test.ts` — 14 tests for detection logic
- `tests/client/create-factory.test.ts` — 4 tests for factory method
- All tests use mocked `PublicClient` (no real RPC calls)

## Backward Compatibility

This is a **purely additive** change. The existing `ClobClient` constructor, `SignatureType` enum, and all current APIs remain unchanged. Users can adopt `ClobClient.create()` at their own pace.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6df67461-ef30-4cc2-8729-1e4747cb05a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6df67461-ef30-4cc2-8729-1e4747cb05a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

