### PR TITLE
feat(logs): add silenceLogs field to client class

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -172,6 +172,8 @@ export class ClobClient {
 
     readonly throwOnError: boolean;
 
+    readonly silenceLogs?: boolean;
+
     private tickSizeTimestamps: Record<string, number>;
 
     private readonly tickSizeTtlMs: number;
@@ -191,6 +193,7 @@ export class ClobClient {
         retryOnError?: boolean,
         tickSizeTtlMs?: number,
         throwOnError?: boolean,
+        logErrors?: boolean,
     ) {
         this.host = host.endsWith("/") ? host.slice(0, -1) : host;
         this.chainId = chainId;
@@ -217,6 +220,7 @@ export class ClobClient {
         this.useServerTime = useServerTime;
         this.retryOnError = retryOnError;
         this.throwOnError = throwOnError ?? false;
+        this.silenceLogs = logErrors ?? false;
         if (builderConfig !== undefined) {
             this.builderConfig = builderConfig;
         }
@@ -695,7 +699,12 @@ export class ClobClient {
     public async getTradesPaginated(
         params?: TradeParams,
         next_cursor?: string,
-    ): Promise<{ trades: Trade[]; next_cursor: string; limit: number; count: number }> {
+    ): Promise<{
+        trades: Trade[];
+        next_cursor: string;
+        limit: number;
+        count: number;
+    }> {
         this.canL2Auth();
 
         const endpoint = GET_TRADES;
@@ -734,7 +743,12 @@ export class ClobClient {
     public async getBuilderTrades(
         params?: TradeParams,
         next_cursor?: string,
-    ): Promise<{ trades: BuilderTrade[]; next_cursor: string; limit: number; count: number }> {
+    ): Promise<{
+        trades: BuilderTrade[];
+        next_cursor: string;
+        limit: number;
+        count: number;
+    }> {
         this.mustBuilderAuth();
 
         const endpoint = GET_BUILDER_TRADES;
@@ -1036,7 +1050,10 @@ export class ClobClient {
             }
         }
 
-        return this.post(`${this.host}${endpoint}`, { headers, data: orderPayload });
+        return this.post(`${this.host}${endpoint}`, {
+            headers,
+            data: orderPayload,
+        });
     }
 
     public async postOrders(
@@ -1082,7 +1099,10 @@ export class ClobClient {
             }
         }
 
-        return this.post(`${this.host}${endpoint}`, { headers, data: ordersPayload });
+        return this.post(`${this.host}${endpoint}`, {
+            headers,
+            data: ordersPayload,
+        });
     }
 
     public async cancelOrder(payload: OrderPayload): Promise<any> {
@@ -1483,10 +1503,14 @@ export class ClobClient {
 
     // http methods
     protected async get(endpoint: string, options?: RequestOptions) {
-        const result = await get(endpoint, {
-            ...options,
-            params: { ...options?.params, geo_block_token: this.geoBlockToken },
-        });
+        const result = await get(
+            endpoint,
+            {
+                ...options,
+                params: { ...options?.params, geo_block_token: this.geoBlockToken },
+            },
+            this.silenceLogs,
+        );
         return this.throwIfError(result);
     }
 
@@ -1498,23 +1522,32 @@ export class ClobClient {
                 params: { ...options?.params, geo_block_token: this.geoBlockToken },
             },
             this.retryOnError,
+            this.silenceLogs,
         );
         return this.throwIfError(result);
     }
 
     protected async put(endpoint: string, options?: RequestOptions) {
-        const result = await put(endpoint, {
-            ...options,
-            params: { ...options?.params, geo_block_token: this.geoBlockToken },
-        });
+        const result = await put(
+            endpoint,
+            {
+                ...options,
+                params: { ...options?.params, geo_block_token: this.geoBlockToken },
+            },
+            this.silenceLogs,
+        );
         return this.throwIfError(result);
     }
 
     protected async del(endpoint: string, options?: RequestOptions) {
-        const result = await del(endpoint, {
-            ...options,
-            params: { ...options?.params, geo_block_token: this.geoBlockToken },
-        });
+        const result = await del(
+            endpoint,
+            {
+                ...options,
+                params: { ...options?.params, geo_block_token: this.geoBlockToken },
+            },
+            this.silenceLogs,
+        );
         return this.throwIfError(result);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -193,7 +193,7 @@ export class ClobClient {
         retryOnError?: boolean,
         tickSizeTtlMs?: number,
         throwOnError?: boolean,
-        logErrors?: boolean,
+        silenceLogs?: boolean,
     ) {
         this.host = host.endsWith("/") ? host.slice(0, -1) : host;
         this.chainId = chainId;
@@ -220,7 +220,7 @@ export class ClobClient {
         this.useServerTime = useServerTime;
         this.retryOnError = retryOnError;
         this.throwOnError = throwOnError ?? false;
-        this.silenceLogs = logErrors ?? false;
+        this.silenceLogs = silenceLogs ?? false;
         if (builderConfig !== undefined) {
             this.builderConfig = builderConfig;
         }

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -69,7 +69,7 @@ export const post = async (
     endpoint: string,
     options?: RequestOptions,
     retryOnError?: boolean,
-    silenceLogs = true,
+    silenceLogs = false,
 ): Promise<any> => {
     try {
         const resp = await request(
@@ -82,7 +82,7 @@ export const post = async (
         return resp.data;
     } catch (err: unknown) {
         if (retryOnError && isTransientAxiosError(err)) {
-            if (silenceLogs) {
+            if (!silenceLogs) {
                 console.log("[CLOB Client] transient error, retrying once after 30 ms");
             }
             await sleep(30);
@@ -96,13 +96,13 @@ export const post = async (
                 );
                 return resp.data;
             } catch (retryErr: unknown) {
-                if (silenceLogs) {
+                if (!silenceLogs) {
                     console.error("[CLOB Client] request error", retryErr);
                 }
                 return errorHandling(retryErr, silenceLogs);
             }
         }
-        if (silenceLogs) {
+        if (!silenceLogs) {
             console.error("[CLOB Client] request error", err);
         }
         return errorHandling(err, silenceLogs);
@@ -112,7 +112,7 @@ export const post = async (
 export const get = async (
     endpoint: string,
     options?: RequestOptions,
-    silenceLogs = true,
+    silenceLogs = false,
 ): Promise<any> => {
     try {
         const resp = await request(endpoint, GET, options?.headers, options?.data, options?.params);
@@ -125,7 +125,7 @@ export const get = async (
 export const del = async (
     endpoint: string,
     options?: RequestOptions,
-    silenceLogs = true,
+    silenceLogs = false,
 ): Promise<any> => {
     try {
         const resp = await request(
@@ -144,7 +144,7 @@ export const del = async (
 export const put = async (
     endpoint: string,
     options?: RequestOptions,
-    silenceLogs = true,
+    silenceLogs = false,
 ): Promise<any> => {
     try {
         const resp = await request(endpoint, PUT, options?.headers, options?.data, options?.params);
@@ -157,7 +157,7 @@ export const put = async (
 const errorHandling = (err: unknown, silenceLogs: boolean) => {
     if (axios.isAxiosError(err)) {
         if (err.response) {
-            if (silenceLogs) {
+            if (!silenceLogs) {
                 console.error(
                     "[CLOB Client] request error",
                     JSON.stringify({
@@ -185,7 +185,7 @@ const errorHandling = (err: unknown, silenceLogs: boolean) => {
         }
 
         if (err.message) {
-            if (silenceLogs) {
+            if (!silenceLogs) {
                 console.error(
                     "[CLOB Client] request error",
                     JSON.stringify({
@@ -197,7 +197,7 @@ const errorHandling = (err: unknown, silenceLogs: boolean) => {
         }
     }
 
-    if (silenceLogs) {
+    if (!silenceLogs) {
         console.error("[CLOB Client] request error", err);
     }
     return { error: err };

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -69,6 +69,7 @@ export const post = async (
     endpoint: string,
     options?: RequestOptions,
     retryOnError?: boolean,
+    silenceLogs = true,
 ): Promise<any> => {
     try {
         const resp = await request(
@@ -81,7 +82,9 @@ export const post = async (
         return resp.data;
     } catch (err: unknown) {
         if (retryOnError && isTransientAxiosError(err)) {
-            console.log("[CLOB Client] transient error, retrying once after 30 ms");
+            if (silenceLogs) {
+                console.log("[CLOB Client] transient error, retrying once after 30 ms");
+            }
             await sleep(30);
             try {
                 const resp = await request(
@@ -93,23 +96,37 @@ export const post = async (
                 );
                 return resp.data;
             } catch (retryErr: unknown) {
-                return errorHandling(retryErr);
+                if (silenceLogs) {
+                    console.error("[CLOB Client] request error", retryErr);
+                }
+                return errorHandling(retryErr, silenceLogs);
             }
         }
-        return errorHandling(err);
+        if (silenceLogs) {
+            console.error("[CLOB Client] request error", err);
+        }
+        return errorHandling(err, silenceLogs);
     }
 };
 
-export const get = async (endpoint: string, options?: RequestOptions): Promise<any> => {
+export const get = async (
+    endpoint: string,
+    options?: RequestOptions,
+    silenceLogs = true,
+): Promise<any> => {
     try {
         const resp = await request(endpoint, GET, options?.headers, options?.data, options?.params);
         return resp.data;
     } catch (err: unknown) {
-        return errorHandling(err);
+        return errorHandling(err, silenceLogs);
     }
 };
 
-export const del = async (endpoint: string, options?: RequestOptions): Promise<any> => {
+export const del = async (
+    endpoint: string,
+    options?: RequestOptions,
+    silenceLogs = true,
+): Promise<any> => {
     try {
         const resp = await request(
             endpoint,
@@ -120,31 +137,38 @@ export const del = async (endpoint: string, options?: RequestOptions): Promise<a
         );
         return resp.data;
     } catch (err: unknown) {
-        return errorHandling(err);
+        return errorHandling(err, silenceLogs);
     }
 };
 
-export const put = async (endpoint: string, options?: RequestOptions): Promise<any> => {
+export const put = async (
+    endpoint: string,
+    options?: RequestOptions,
+    silenceLogs = true,
+): Promise<any> => {
     try {
         const resp = await request(endpoint, PUT, options?.headers, options?.data, options?.params);
         return resp.data;
     } catch (err: unknown) {
-        return errorHandling(err);
+        return errorHandling(err, silenceLogs);
     }
 };
 
-const errorHandling = (err: unknown) => {
+const errorHandling = (err: unknown, silenceLogs: boolean) => {
     if (axios.isAxiosError(err)) {
         if (err.response) {
-            console.error(
-                "[CLOB Client] request error",
-                JSON.stringify({
-                    status: err.response?.status,
-                    statusText: err.response?.statusText,
-                    data: err.response?.data,
-                    config: err.response?.config,
-                }),
-            );
+            if (silenceLogs) {
+                console.error(
+                    "[CLOB Client] request error",
+                    JSON.stringify({
+                        status: err.response?.status,
+                        statusText: err.response?.statusText,
+                        data: err.response?.data,
+                        config: err.response?.config,
+                    }),
+                );
+            }
+
             if (err.response?.data) {
                 if (
                     typeof err.response?.data === "string" ||
@@ -161,17 +185,21 @@ const errorHandling = (err: unknown) => {
         }
 
         if (err.message) {
-            console.error(
-                "[CLOB Client] request error",
-                JSON.stringify({
-                    error: err.message,
-                }),
-            );
+            if (silenceLogs) {
+                console.error(
+                    "[CLOB Client] request error",
+                    JSON.stringify({
+                        error: err.message,
+                    }),
+                );
+            }
             return { error: err.message };
         }
     }
 
-    console.error("[CLOB Client] request error", err);
+    if (silenceLogs) {
+        console.error("[CLOB Client] request error", err);
+    }
     return { error: err };
 };
 

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -96,14 +96,8 @@ export const post = async (
                 );
                 return resp.data;
             } catch (retryErr: unknown) {
-                if (!silenceLogs) {
-                    console.error("[CLOB Client] request error", retryErr);
-                }
                 return errorHandling(retryErr, silenceLogs);
             }
-        }
-        if (!silenceLogs) {
-            console.error("[CLOB Client] request error", err);
         }
         return errorHandling(err, silenceLogs);
     }


### PR DESCRIPTION
Adding an optional `silenceLogs` field on the client class. On http errors, logs of API and Builder keys were being propagated to datadog.

slienceLogs behavior is defaulted to false and shouldn't change anything for downstream users without this field defined


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged by default and only gates console logging on request failures/retries. Main risk is reduced observability if enabled, or missing propagation to any external callers of `http-helpers`.
> 
> **Overview**
> Adds an optional `silenceLogs` flag to `ClobClient` (default `false`) and threads it through the internal `get`/`post`/`put`/`del` wrappers.
> 
> Updates `src/http-helpers` to accept `silenceLogs` and conditionally suppress `console.log`/`console.error` output during transient-retry messaging and error handling, reducing the chance of sensitive request config being logged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1577f0a05a1dca675d2ef3576890db5f02cad21c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->