### PR TITLE
remove console.log/console.error calls from http-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/clob-client",
     "description": "Typescript client for Polymarket's CLOB",
-    "version": "5.8.0",
+    "version": "5.8.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Polymarket/clob-client.git"

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -81,7 +81,6 @@ export const post = async (
         return resp.data;
     } catch (err: unknown) {
         if (retryOnError && isTransientAxiosError(err)) {
-            console.log("[CLOB Client] transient error, retrying once after 30 ms");
             await sleep(30);
             try {
                 const resp = await request(
@@ -136,15 +135,6 @@ export const put = async (endpoint: string, options?: RequestOptions): Promise<a
 const errorHandling = (err: unknown) => {
     if (axios.isAxiosError(err)) {
         if (err.response) {
-            console.error(
-                "[CLOB Client] request error",
-                JSON.stringify({
-                    status: err.response?.status,
-                    statusText: err.response?.statusText,
-                    data: err.response?.data,
-                    config: err.response?.config,
-                }),
-            );
             if (err.response?.data) {
                 if (
                     typeof err.response?.data === "string" ||
@@ -161,17 +151,10 @@ const errorHandling = (err: unknown) => {
         }
 
         if (err.message) {
-            console.error(
-                "[CLOB Client] request error",
-                JSON.stringify({
-                    error: err.message,
-                }),
-            );
             return { error: err.message };
         }
     }
 
-    console.error("[CLOB Client] request error", err);
     return { error: err };
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes `console.log`/`console.error` side effects without changing request/retry behavior or error payload shapes; primary impact is reduced runtime diagnostics during failures.
> 
> **Overview**
> Removes all `console.log`/`console.error` output from `src/http-helpers` during transient retry and error handling, leaving callers to handle/log failures themselves.
> 
> Bumps package version from `5.8.0` to `5.8.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 099979c750b80c5d14ad1186fa5a1adf6f0f29e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->