### PR TITLE
TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "dotenv": "^17.3.1",
         "ethers": "^5.8.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.0",
         "vitest": "^4.0.18",
         "ws": "^8.11.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.1.1
       viem:
         specifier: ^2.46.3
-        version: 2.46.3(typescript@5.9.3)
+        version: 2.46.3(typescript@6.0.2)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.5
@@ -43,8 +43,8 @@ importers:
         specifier: ^5.8.0
         version: 5.8.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.2
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.2)(jsdom@20.0.3)
@@ -1063,8 +1063,8 @@ packages:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1793,9 +1793,9 @@ snapshots:
   abab@2.0.6:
     optional: true
 
-  abitype@1.2.3(typescript@5.9.3):
+  abitype@1.2.3(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   acorn-globals@7.0.1:
     dependencies:
@@ -2208,7 +2208,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  ox@0.12.4(typescript@5.9.3):
+  ox@0.12.4(typescript@6.0.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2216,10 +2216,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@6.0.2)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - zod
 
@@ -2341,7 +2341,7 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@6.21.0: {}
 
@@ -2354,18 +2354,18 @@ snapshots:
       requires-port: 1.0.0
     optional: true
 
-  viem@2.46.3(typescript@5.9.3):
+  viem@2.46.3(typescript@6.0.2):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@6.0.2)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@5.9.3)
+      ox: 0.12.4(typescript@6.0.2)
       ws: 8.18.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
+        "rootDir": "./src",
         "types": ["node"]
     },
     "include": ["src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
         "node_modules",
     ],
     "compilerOptions": {
-        "baseUrl": "./",
         "module": "nodenext",
         "moduleResolution": "nodenext",
         "target": "es2022",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Major TypeScript upgrade can change typechecking/build behavior and may surface new compile errors or subtly alter emitted output. Config tweaks (`rootDir`, removal of `baseUrl`) could also impact module resolution in builds.
> 
> **Overview**
> Upgrades the project toolchain to **TypeScript 6** (updates `package.json` and `pnpm-lock.yaml`, including TS peer resolutions for packages like `viem`).
> 
> Adjusts TypeScript configuration by removing `compilerOptions.baseUrl` from `tsconfig.json` and setting `compilerOptions.rootDir` to `./src` in `tsconfig.build.json` to better constrain build inputs/outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a4dc855205c38a9b67dae5e37e3808234c5a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->