### PR TITLE
Pin axios to 1.14.0 to avoid compromised version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     },
     "dependencies": {
         "@polymarket/builder-signing-sdk": "^1.0.0",
-        "axios": "^1.0.0",
+        "axios": "1.14.0",
         "browser-or-node": "^2.1.1",
         "viem": "^2.46.3"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       axios:
-        specifier: ^1.0.0
-        version: 1.13.2
+        specifier: 1.14.0
+        version: 1.14.0
       browser-or-node:
         specifier: ^2.1.1
         version: 2.1.1
@@ -657,8 +657,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
@@ -980,8 +980,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -1623,7 +1624,7 @@ snapshots:
 
   '@polymarket/builder-signing-sdk@1.0.0':
     dependencies:
-      axios: 1.13.2
+      axios: 1.14.0
     transitivePeerDependencies:
       - debug
 
@@ -1830,11 +1831,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.13.2:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -2240,7 +2241,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   psl@1.15.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Pins `axios` from `^1.0.0` to `1.14.0` to prevent installing the compromised `1.14.1` version
- axios 1.14.1 was published March 30, 2026 via a hijacked maintainer account and contains a malicious `plain-crypto-js` dependency that deploys a cross-platform RAT
- See: https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan

## Test plan
- [ ] Verify `pnpm install` resolves axios to exactly 1.14.0
- [ ] Confirm no `plain-crypto-js` in node_modules
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency change that only affects the resolved `axios` (and its lockfile transitive `proxy-from-env`) versions; runtime behavior should be effectively unchanged aside from any patch-level axios differences.
> 
> **Overview**
> Prevents installs from floating to newer `axios` releases by changing the dependency range from `^1.0.0` to an exact `1.14.0`.
> 
> Updates `pnpm-lock.yaml` to lock `axios@1.14.0` (including the related transitive bump to `proxy-from-env@2.1.0`) and aligns the `@polymarket/builder-signing-sdk` dependency tree to the same axios version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 918fd5bf8ac0faf1f96c2734601826779abfd0d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->