### PR TITLE
fix: use funderAddress for POLY_ADDRESS header in Magic wallet flows

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -171,6 +171,7 @@ export class ClobClient {
     readonly retryOnError?: boolean;
 
     readonly throwOnError: boolean;
+    readonly funderAddress?: string;
 
     private tickSizeTimestamps: Record<string, number>;
 
@@ -217,6 +218,7 @@ export class ClobClient {
         this.useServerTime = useServerTime;
         this.retryOnError = retryOnError;
         this.throwOnError = throwOnError ?? false;
+        this.funderAddress = funderAddress;
         if (builderConfig !== undefined) {
             this.builderConfig = builderConfig;
         }
@@ -227,6 +229,7 @@ export class ClobClient {
             creds: this.creds,
             useServerTime: this.useServerTime,
             geoBlockToken: this.geoBlockToken,
+            funderAddress: this.funderAddress,
             userType: this.orderBuilder.signatureType,
             getServerTime: this.getServerTime.bind(this),
             getTickSize: this.getTickSize.bind(this),
@@ -505,6 +508,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, { headers });
@@ -524,6 +528,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, { headers });
@@ -543,6 +548,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.del(`${this.host}${endpoint}`, { headers });
@@ -566,6 +572,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.post(`${this.host}${endpoint}`, { headers });
@@ -585,6 +592,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, { headers });
@@ -611,6 +619,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.del(`${this.host}${endpoint}`, { headers, data: payload });
@@ -642,6 +651,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         // builders flow
@@ -673,6 +683,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         let results: Trade[] = [];
@@ -709,6 +720,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         next_cursor = next_cursor || INITIAL_CURSOR;
@@ -783,6 +795,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, {
@@ -805,6 +818,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.del(`${this.host}${endpoint}`, {
@@ -829,6 +843,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         const _params = {
@@ -853,6 +868,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         const _params = {
@@ -968,6 +984,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         // builders flow
@@ -1023,6 +1040,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         // builders flow
@@ -1069,6 +1087,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         // builders flow
@@ -1099,6 +1118,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
         return this.del(`${this.host}${endpoint}`, { headers, data: payload });
     }
@@ -1117,6 +1137,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
         return this.del(`${this.host}${endpoint}`, { headers, data: ordersHashes });
     }
@@ -1134,6 +1155,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
         return this.del(`${this.host}${endpoint}`, { headers });
     }
@@ -1165,6 +1187,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.post(`${this.host}${endpoint}`, { headers, data: serialized });
@@ -1184,6 +1207,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
         return this.del(`${this.host}${endpoint}`, { headers, data: payload });
     }
@@ -1202,6 +1226,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, { headers, params });
@@ -1223,6 +1248,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.post(`${this.host}${endpoint}`, {
@@ -1246,6 +1272,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         let results: UserEarning[] = [];
@@ -1281,6 +1308,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         const params = {
@@ -1313,6 +1341,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         let results: UserRewardsEarning[] = [];
@@ -1351,6 +1380,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         const _params = {
@@ -1426,6 +1456,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.post(`${this.host}${endpoint}`, { headers });
@@ -1445,6 +1476,7 @@ export class ClobClient {
             this.creds as ApiKeyCreds,
             headerArgs,
             this.useServerTime ? await this.getServerTime() : undefined,
+            this.funderAddress,
         );
 
         return this.get(`${this.host}${endpoint}`, { headers });

--- a/src/headers/index.ts
+++ b/src/headers/index.ts
@@ -16,6 +16,7 @@ export const createL1Headers = async (
     chainId: Chain,
     nonce?: number,
     timestamp?: number,
+    funderAddress?: string,
 ): Promise<L1PolyHeader> => {
     let ts = Math.floor(Date.now() / 1000);
     if (timestamp !== undefined) {
@@ -27,7 +28,7 @@ export const createL1Headers = async (
     }
 
     const sig = await buildClobEip712Signature(signer, chainId, ts, n);
-    const address = await getSignerAddress(signer);
+    const address = funderAddress ?? (await getSignerAddress(signer));
 
     const headers = {
         POLY_ADDRESS: address,
@@ -43,12 +44,13 @@ export const createL2Headers = async (
     creds: ApiKeyCreds,
     l2HeaderArgs: L2HeaderArgs,
     timestamp?: number,
+    funderAddress?: string,
 ): Promise<L2PolyHeader> => {
     let ts = Math.floor(Date.now() / 1000);
     if (timestamp !== undefined) {
         ts = timestamp;
     }
-    const address = await getSignerAddress(signer);
+    const address = funderAddress ?? (await getSignerAddress(signer));
 
     const sig = await buildPolyHmacSignature(
         creds.secret,

--- a/src/rfq-client.ts
+++ b/src/rfq-client.ts
@@ -137,6 +137,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.post(`${this.deps.host}${endpoint}`, { headers, data: payload });
@@ -160,6 +161,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.del(`${this.deps.host}${endpoint}`, { headers, data: request });
@@ -182,6 +184,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         const query = buildRepeatedQuery(params);
@@ -267,6 +270,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.post(`${this.deps.host}${endpoint}`, { headers, data: quoteWithUserType });
@@ -290,6 +294,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         const query = buildRepeatedQuery(params);
@@ -318,6 +323,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         const query = buildRepeatedQuery(params);
@@ -344,6 +350,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.get(`${this.deps.host}${endpoint}`, { headers, params });
@@ -367,6 +374,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.del(`${this.deps.host}${endpoint}`, { headers, data: quote });
@@ -389,6 +397,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.get(`${this.deps.host}${endpoint}`, { headers });
@@ -457,6 +466,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.post(`${this.deps.host}${endpoint}`, { headers, data: acceptPayload });
@@ -523,6 +533,7 @@ export class RfqClient implements IRfqClient {
             this.deps.creds as ApiKeyCreds,
             l2HeaderArgs,
             this.deps.useServerTime ? await this.deps.getServerTime() : undefined,
+            this.deps.funderAddress,
         );
 
         return this.deps.post(`${this.deps.host}${endpoint}`, { headers, data: approvePayload });

--- a/src/rfq-deps.ts
+++ b/src/rfq-deps.ts
@@ -35,6 +35,7 @@ export interface RfqDeps {
     useServerTime?: boolean;
 
     geoBlockToken?: string;
+    funderAddress?: string;
 
     /**
      * Numeric user type (backed by SignatureType in the order builder).

--- a/tests/headers/index.test.ts
+++ b/tests/headers/index.test.ts
@@ -113,4 +113,37 @@ describe("headers", () => {
             expect(l2Headers.POLY_PASSPHRASE).equal(creds.passphrase);
         });
     });
+
+    describe("funderAddress override", () => {
+        const funder = "0x1234567890abcdef1234567890abcdef12345678";
+
+        it("L1 headers use funderAddress for POLY_ADDRESS when provided", async () => {
+            const l1Headers = await createL1Headers(wallet, chainId, 0, undefined, funder);
+            expect(l1Headers.POLY_ADDRESS).equal(funder);
+            expect(l1Headers.POLY_SIGNATURE).not.empty;
+        });
+
+        it("L1 headers fall back to signer address when funderAddress is undefined", async () => {
+            const l1Headers = await createL1Headers(wallet, chainId, 0, undefined, undefined);
+            expect(l1Headers.POLY_ADDRESS).equal(wallet.address);
+        });
+
+        it("L2 headers use funderAddress for POLY_ADDRESS when provided", async () => {
+            const l2Headers = await createL2Headers(wallet, creds, {
+                method: "get",
+                requestPath: "/order",
+            }, undefined, funder);
+            expect(l2Headers.POLY_ADDRESS).equal(funder);
+            expect(l2Headers.POLY_SIGNATURE).not.empty;
+            expect(l2Headers.POLY_API_KEY).equal(creds.key);
+        });
+
+        it("L2 headers fall back to signer address when funderAddress is undefined", async () => {
+            const l2Headers = await createL2Headers(wallet, creds, {
+                method: "get",
+                requestPath: "/order",
+            }, undefined, undefined);
+            expect(l2Headers.POLY_ADDRESS).equal(wallet.address);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #248.

When using Magic wallet (POLY_PROXY signature type), the API key is associated with the `funderAddress`, not the signer address. Currently, `createL1Headers` and `createL2Headers` always resolve `POLY_ADDRESS` from the signer, causing L2 authenticated requests to fail for proxy/Magic wallet users because the server expects the funder address.

## Changes

- Added optional `funderAddress` parameter to `createL1Headers` and `createL2Headers` in `src/headers/index.ts`
- Address resolution now uses `funderAddress ?? (await getSignerAddress(signer))`, preserving backward compatibility for non-proxy wallets
- Stored the existing `funderAddress` constructor param as a class property on `ClobClient` and pass it through to all `createL2Headers` call sites (29 in `client.ts`, 11 in `rfq-client.ts`)
- Added `funderAddress` to `RfqDeps` interface and wired it through the RFQ client
- Added 4 unit tests covering L1/L2 funderAddress override and fallback behavior

## Test plan

- [x] `tsc --noEmit` passes
- [x] All existing + new header tests pass (`vitest run tests/headers/`)
- [x] Build succeeds (`tsc -p tsconfig.build.json`)
- [x] No new lint errors introduced (pre-existing CRLF warnings unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request authentication headers used across many L2 endpoints; a wrong `POLY_ADDRESS` could break signed requests or affect account attribution, though changes are additive and fallback to signer behavior.
> 
> **Overview**
> Fixes proxy/Magic-wallet flows by allowing an optional `funderAddress` to override `POLY_ADDRESS` in `createL1Headers` and `createL2Headers`, falling back to the signer-derived address when not provided.
> 
> Threads this `funderAddress` through `ClobClient` into RFQ dependencies and passes it to all `createL2Headers` call sites so L2-authenticated CLOB/RFQ requests use the expected address. Adds unit tests covering override and fallback behavior for both L1 and L2 headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a67622138e845a3bd0147da9505d4597fcc8a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->