### PR TITLE
deposit wallet init

### DIFF
--- a/examples/signatureTypes.ts
+++ b/examples/signatureTypes.ts
@@ -42,9 +42,21 @@ async function main() {
         gnosisSafeAddress,
     );
 
+    // Client used with a Polymarket Deposit Wallet: Signature type 3
+    const depositWalletAddress = "0x...";
+    const depositWalletClient = new ClobClient(
+        host,
+        chainId,
+        wallet,
+        creds,
+        SignatureType.POLY_DEPOSIT_WALLET,
+        depositWalletAddress,
+    );
+
     void clobClient;
     void polyProxyClient;
     void polyGnosisSafeClient;
+    void depositWalletClient;
 }
 
 main();

--- a/src/order-utils/model/signature-types.model.ts
+++ b/src/order-utils/model/signature-types.model.ts
@@ -13,4 +13,10 @@ export enum SignatureType {
      * EIP712 signatures signed by EOAs that own Polymarket Gnosis safes
      */
     POLY_GNOSIS_SAFE = 2,
+
+    /**
+     * EIP712 signatures signed by EOAs that own Polymarket Deposit Wallets.
+     * Validated on-chain via ERC-1271 isValidSignature() with ERC-7739 nested domain wrapping.
+     */
+    POLY_DEPOSIT_WALLET = 3,
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `SignatureType` enum value that may affect downstream logic that assumes only types 0–2, potentially impacting order signing/validation flows for clients upgrading.
> 
> **Overview**
> Adds a new signature mode, `SignatureType.POLY_DEPOSIT_WALLET = 3`, documented as ERC-1271 `isValidSignature()` validation with ERC-7739 nested domain wrapping.
> 
> Updates `examples/signatureTypes.ts` to show how to initialize a `ClobClient` for a Polymarket Deposit Wallet using the new signature type and wallet address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab376cde87411a6b8f943005cc162de4f8d4230f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->