### PR TITLE
No Retry on 500s

### DIFF
--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -59,8 +59,6 @@ const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 const isTransientAxiosError = (err: unknown): boolean => {
     if (!axios.isAxiosError(err)) return false;
     if (!err.response) return true; // network error
-    const status = err.response.status ?? 0;
-    if (status >= 500 && status < 600) return true; // 5xx
     const code = (err.code ?? "").toString();
     return ["ECONNABORTED", "ENETUNREACH", "EAI_AGAIN", "ETIMEDOUT"].includes(code);
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes retry behavior for POST requests by no longer treating HTTP 5xx responses as transient, which may reduce load on failing services but could also decrease resilience to brief server hiccups.
> 
> **Overview**
> Removes automatic retry-on-error behavior for POST requests when the server returns an HTTP 5xx response.
> 
> `isTransientAxiosError` now only classifies network/timeout-related Axios errors as retryable, so `retryOnError` no longer triggers a second attempt for 5xx failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1efa46f9cd7df35b7a0665bc3f5b07029608a625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->