### PR TITLE
docs(readme): clarify signer compatibility (ethers v5 vs v6, viem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ const signatureType = 1;
 
 See [examples](examples/) for more information
 
+### Signer compatibility
+
+`ClobClient` accepts the following signer types:
+
+- **viem `WalletClient`** (recommended) — see [Using viem WalletClient](#using-viem-walletclient).
+- **ethers v5** — any signer exposing `_signTypedData` and `getAddress`, including `Wallet` from `ethers@^5` or the standalone `@ethersproject/wallet` package (used in the example above).
+- **ethers v6 is not directly supported.** v6 renamed `_signTypedData` to `signTypedData`, which this client's ethers path still requires. If you are on ethers v6, use a viem `WalletClient` instead.
+
+`ethers` is not a runtime dependency of this package — install it only if you pass an ethers signer.
+
 ### Using viem WalletClient
 
 ```ts


### PR DESCRIPTION
Closes #256.

### What changed
Adds a short **Signer compatibility** section to `README.md` that states explicitly which signers `ClobClient` accepts.

### Why
The original example imports `@ethersproject/wallet` (ethers v5) without telling the reader that the library does not require ethers at all, and without flagging the ethers v6 mismatch.

`src/signer.ts` currently accepts:

```ts
interface EthersSigner {
    _signTypedData(domain, types, value): Promise<string>;
    getAddress(): Promise<string>;
}
export type ClobSigner = EthersSigner | WalletClient;
```

ethers v6 renamed `_signTypedData` → `signTypedData`, so an ethers v6 `Wallet` fails the `isEthersTypedDataSigner` check and, if it falls through to the viem path via `isWalletClientSigner`, its call signature does not match what `signTypedDataWithSigner` invokes. That is what issue #256 is describing.

The new section:
- Points new users to viem as the recommended path.
- Documents that ethers v5 (`ethers@^5` or `@ethersproject/wallet`) works.
- States ethers v6 is not directly supported and explains why, with the recommended workaround.
- Notes that `ethers` is not a runtime dependency of this package.

### Scope
- One file (`README.md`), additive section only.
- Does not touch existing Usage or Using viem WalletClient blocks.
- Does not overlap with PR #257 (different section).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Adds a new **Signer compatibility** section to `README.md` that explicitly documents supported signer types for `ClobClient` (recommended `viem` `WalletClient`, `ethers` v5-compatible signers) and calls out that **ethers v6 is not directly supported** due to the `_signTypedData` rename.
> 
> Also clarifies that `ethers` is not a runtime dependency and only needs to be installed when using an ethers-based signer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bd4be2f9703383ef36fe07ee2c67c2e52b5be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->