### PR TITLE
docs: add archive notice and link to V2 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!WARNING]
+> This repository has been archived and is no longer maintained.
+>
+> The client is no longer functional and should not be used for new or existing integrations.
+>
+> Please migrate to the V2 client:
+> https://github.com/Polymarket/clob-client-v2
+
 # Polymarket CLOB Client
 
 <a href='https://www.npmjs.com/package/@polymarket/clob-client'>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or runtime behavior is modified.
> 
> **Overview**
> Adds a prominent `WARNING` banner at the top of `README.md` stating the repository is archived, the client is no longer functional, and directing users to migrate to `clob-client-v2` via a GitHub link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d0467bb653d5feec12efbd03e0473d1aa50f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->